### PR TITLE
Add Qt Wayland platform plugin

### DIFF
--- a/dev-qt/qtwayland/metadata.xml
+++ b/dev-qt/qtwayland/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>qt</herd>
+	<use>
+		<flag name="c++11">Build Qt using the C++11 standard</flag>
+		<flag name="qml">Build QML/QtQuick bindings</flag>
+		<flag name="wayland-compositor">Build Qt compositor for wayland</flag>
+	</use>
+	<upstream>
+		<bugs-to>https://bugreports.qt-project.org/</bugs-to>
+		<doc>http://qt-project.org/doc/</doc>
+	</upstream>
+</pkgmetadata>

--- a/dev-qt/qtwayland/qtwayland-5.1.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.1.9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit qt5-build
+
+DESCRIPTION="Wayland plugin for Qt"
+HOMEPAGE="http://qt-project.org/wiki/QtWayland"
+
+if [[ ${QT5_BUILD_TYPE} == live ]]; then
+	KEYWORDS=""
+else
+	KEYWORDS="~amd64"
+fi
+
+IUSE="qml wayland-compositor"
+
+DEPEND="
+	>=dev-libs/wayland-1.1.0
+	>=dev-qt/qtcore-${PV}:5[debug=]
+	>=dev-qt/qtgui-${PV}:5[debug=,opengl]
+	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	if use wayland-compositor; then
+		echo "CONFIG += wayland-compositor" >> "${QT5_BUILD_DIR}"/.qmake.cache
+	fi
+	qt5-build_src_configure
+}

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit qt5-build
+
+DESCRIPTION="Wayland plugin for Qt"
+HOMEPAGE="http://qt-project.org/wiki/QtWayland"
+
+if [[ ${QT5_BUILD_TYPE} == live ]]; then
+	KEYWORDS=""
+else
+	KEYWORDS="~amd64"
+fi
+
+IUSE="qml wayland-compositor"
+
+DEPEND="
+	>=dev-libs/wayland-1.1.0
+	>=dev-qt/qtcore-${PV}:5[debug=]
+	>=dev-qt/qtgui-${PV}:5[debug=,opengl]
+	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	if use wayland-compositor; then
+		echo "CONFIG += wayland-compositor" >> "${QT5_BUILD_DIR}"/.qmake.cache
+	fi
+	qt5-build_src_configure
+}


### PR DESCRIPTION
1. Bug https://bugs.gentoo.org/show_bug.cgi?id=480654
   "[qt overlay] dev-qt/qtgui with USE="gles2" doesn't enable opengles2
   in QT_CONFIG" should be fixed before, or
   /usr/lib/qt5/mkspecs/qconfig.pri edited manually.
2. qtwayland-5.9999 USE=wayland-compositor doesn't compiles right now
   (upstream issue)

Signed-off-by: Maksim Melnikau maxposedon@gmail.com
