### PR TITLE
[dev-libs/extra-cmake-tools] Add kde-independent ebuilds

### DIFF
--- a/dev-libs/extra-cmake-modules/extra-cmake-modules-0.0.8.ebuild
+++ b/dev-libs/extra-cmake-modules/extra-cmake-modules-0.0.8.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+
+DESCRIPTION="Extra modules and scripts for CMake"
+HOMEPAGE="http://www.kde.org/"
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+EGIT_COMMIT="cc628694c9e55ffb38fad6e8bfc071fa4e09609b"
+KEYWORDS=""
+LICENSE="BSD"
+SLOT=0
+KEYWORDS=""
+
+inherit cmake-utils git-2
+
+DEPEND="
+	>=dev-util/cmake-2.8.11
+"
+RESTRICT="test"
+
+src_prepare() {
+	sed -e 's|man/man7|share/&|' -i CMakeLists.txt || die
+	cmake-utils_src_prepare
+}

--- a/dev-libs/extra-cmake-modules/extra-cmake-modules-9999.ebuild
+++ b/dev-libs/extra-cmake-modules/extra-cmake-modules-9999.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+
+DESCRIPTION="Extra modules and scripts for CMake"
+HOMEPAGE="http://www.kde.org/"
+EGIT_REPO_URI="git://anongit.kde.org/${PN}"
+KEYWORDS=""
+LICENSE="BSD"
+SLOT=0
+KEYWORDS=""
+
+inherit cmake-utils git-2
+
+DEPEND="
+	>=dev-util/cmake-2.8.11
+"
+RESTRICT="test"
+
+src_prepare() {
+	sed -e 's|man/man7|share/&|' -i CMakeLists.txt || die
+	cmake-utils_src_prepare
+}


### PR DESCRIPTION
This add ebuilds for extra-cmake-modules which are needed by some packages for Qt5 compilation.

As there are no real releases, just version number increments, I made a 0.0.8 ebuild with the last commit before the version bump. Sadly current head requires (unreleased) Qt 5.2.0 so that for building packages for Qt 5.1 we need 0.0.8.
