### PR TITLE
[app-crypt/qca] Add qt5 supporting 9999 ebuild

### DIFF
--- a/app-crypt/qca/metadata.xml
+++ b/app-crypt/qca/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd></herd>
+	<use>
+		<flag name='botan'>Enable botan plugin</flag>
+		<flag name='sasl'>Enable cyrus-sasl plugin</flag>
+		<flag name='gcrypt'>Enable gcrypt plugin</flag>
+		<flag name='gpg'>Enable GnuPG plugin</flag>
+		<flag name='logger'>Enable logger plugin</flag>
+		<flag name='nss'>Enable NSS plugin</flag>
+		<flag name='openssl'>Enable OpenSSL plugin</flag>
+		<flag name='pkcs11'>Enable PKCS#11 plugin</flag>
+		<flag name='softstore'>Enable softstore plugin</flag>
+	</use>
+</pkgmetadata>

--- a/app-crypt/qca/qca-9999.ebuild
+++ b/app-crypt/qca/qca-9999.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit cmake-utils git-r3
+
+DESCRIPTION="Qt Cryptographic Architecture (QCA)"
+HOMEPAGE="http://delta.affinix.com/qca/"
+EGIT_REPO_URI="git://anongit.kde.org/${PN}.git"
+
+LICENSE="LGPL-2.1"
+SLOT="2"
+KEYWORDS=""
+IUSE="botan debug doc examples gcrypt gpg logger nss openssl pkcs11 +qt4 qt5 sasl softstore test"
+
+RDEPEND="
+	botan? ( dev-libs/botan )
+	sasl? ( dev-libs/cyrus-sasl )
+	gcrypt? ( dev-libs/libgcrypt:= )
+	gpg? ( app-crypt/gnupg )
+	nss? ( dev-libs/nss )
+	openssl? ( dev-libs/openssl:0 )
+	pkcs11? (
+		dev-libs/openssl:0
+		>=dev-libs/pkcs11-helper-1.02
+	)
+	qt4? ( dev-qt/qtcore:4 )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtconcurrent:5
+		dev-qt/qtnetwork:5
+	)"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen )
+	test? (
+		qt4? ( dev-qt/qttest:4 )
+		qt5? ( dev-qt/qttest:5 )
+	)
+	!<app-crypt/qca-1.0-r3:0"
+
+REQUIRED_USE="^^ ( qt4 qt5 )"
+
+DOCS=( README TODO )
+
+with_plugin_use() {
+	[[ -z $1 ]] && die "with_plugin_use <USE flag> [<flag name>]"
+	echo "-DWITH_${2:-$1}_PLUGIN=$(use $1 && echo yes || echo no)"
+}
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use qt4 QT4_BUILD)
+		$(cmake-utils_use test BUILD_TESTS)
+		$(with_plugin_use botan)
+		$(with_plugin_use sasl cyrus-sasl)
+		$(with_plugin_use gcrypt)
+		$(with_plugin_use gpg gnupg)
+		$(with_plugin_use logger)
+		$(with_plugin_use nss)
+		$(with_plugin_use openssl ossl)
+		$(with_plugin_use pkcs11)
+		$(with_plugin_use softstore)
+	)
+
+	cmake-utils_src_configure
+}
+
+src_install() {
+	cmake-utils_src_install
+
+	if use doc; then
+		pushd "${BUILD_DIR}"
+		doxygen Doxyfile
+		dohtml apidocs/html/*
+		popd
+	fi
+
+	if use examples; then
+		insinto /usr/share/doc/${PF}/
+		doins -r "${S}"/examples
+	fi
+}

--- a/dev-libs/qoauth/qoauth-9999.ebuild
+++ b/dev-libs/qoauth/qoauth-9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="${COMMON_DEPEND}
 	test? ( dev-qt/qttest:4 )
 "
 RDEPEND="${COMMON_DEPEND}
-	app-crypt/qca-ossl:2[debug?]
+	|| ( ~app-crypt/qca-9999:2[debug?,openssl,qt4] <app-crypt/qca-ossl-9999:2[debug?] )
 "
 
 DOCS="README CHANGELOG"


### PR DESCRIPTION
Add an ebuild for QCA head which enables compiling with Qt5.
- Using CMake as (new) preferred build system, plugins are now implemented as USE flags instead of separate packages like in portage.
- Fixed qoauth ebuild to support the new USE-flag system
- Depends on https://github.com/gentoo/qt/pull/13
