### PR TITLE
eclass/qt5-build: convert QCONFIG_* to arrays, migrate ebuilds

### DIFF
--- a/dev-qt/qtcore/qtcore-5.1.1.ebuild
+++ b/dev-qt/qtcore/qtcore-5.1.1.ebuild
@@ -33,11 +33,13 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/rcc
 	src/corelib
 )
-QCONFIG_DEFINE="QT_ZLIB"
+QCONFIG_DEFINE=( QT_ZLIB )
 
 pkg_setup() {
-	QCONFIG_REMOVE="$(usev !glib)
-			$(usev !icu)"
+	QCONFIG_REMOVE=(
+		$(usev !glib)
+		$(usev !icu)
+	)
 
 	qt5-build_pkg_setup
 }

--- a/dev-qt/qtcore/qtcore-5.2.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.2.9999.ebuild
@@ -33,11 +33,13 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/rcc
 	src/corelib
 )
-QCONFIG_DEFINE="QT_ZLIB"
+QCONFIG_DEFINE=( QT_ZLIB )
 
 pkg_setup() {
-	QCONFIG_REMOVE="$(usev !glib)
-			$(usev !icu)"
+	QCONFIG_REMOVE=(
+		$(usev !glib)
+		$(usev !icu)
+	)
 
 	qt5-build_pkg_setup
 }

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -33,11 +33,13 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/rcc
 	src/corelib
 )
-QCONFIG_DEFINE="QT_ZLIB"
+QCONFIG_DEFINE=( QT_ZLIB )
 
 pkg_setup() {
-	QCONFIG_REMOVE="$(usev !glib)
-			$(usev !icu)"
+	QCONFIG_REMOVE=(
+		$(usev !glib)
+		$(usev !icu)
+	)
 
 	qt5-build_pkg_setup
 }

--- a/dev-qt/qtdbus/qtdbus-5.1.1.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.1.1.ebuild
@@ -30,7 +30,7 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/qdbusxml2cpp
 	src/tools/qdbuscpp2xml
 )
-QCONFIG_ADD="dbus dbus-linked"
+QCONFIG_ADD=( dbus dbus-linked )
 
 src_configure() {
 	local myconf=(

--- a/dev-qt/qtdbus/qtdbus-5.2.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.2.9999.ebuild
@@ -30,7 +30,7 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/qdbusxml2cpp
 	src/tools/qdbuscpp2xml
 )
-QCONFIG_ADD="dbus dbus-linked"
+QCONFIG_ADD=( dbus dbus-linked )
 
 src_configure() {
 	local myconf=(

--- a/dev-qt/qtdbus/qtdbus-5.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.9999.ebuild
@@ -30,7 +30,7 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/qdbusxml2cpp
 	src/tools/qdbuscpp2xml
 )
-QCONFIG_ADD="dbus dbus-linked"
+QCONFIG_ADD=( dbus dbus-linked )
 
 src_configure() {
 	local myconf=(

--- a/dev-qt/qtgui/qtgui-5.1.1.ebuild
+++ b/dev-qt/qtgui/qtgui-5.1.1.ebuild
@@ -71,7 +71,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="
+	QCONFIG_ADD=(
 		$(use accessibility && echo accessibility-atspi-bridge)
 		$(usev eglfs)
 		$(usev evdev)
@@ -80,12 +80,15 @@ pkg_setup() {
 		$(usev kms)
 		$(usev opengl)
 		$(use udev && echo libudev)
-		$(usev xcb)"
+		$(usev xcb)
+	)
 
-	QCONFIG_DEFINE="$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
+	QCONFIG_DEFINE=(
+			$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
 			$(use eglfs && echo QT_EGLFS)
 			$(use gles2 && echo QT_EGL)
-			$(use jpeg && echo QT_IMAGEFORMAT_JPEG)"
+			$(use jpeg && echo QT_IMAGEFORMAT_JPEG)
+	)
 
 	use opengl && QT5_TARGET_SUBDIRS+=(src/openglextensions)
 

--- a/dev-qt/qtgui/qtgui-5.2.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.2.9999.ebuild
@@ -79,7 +79,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="
+	QCONFIG_ADD=(
 		$(use accessibility && echo accessibility-atspi-bridge)
 		$(usev eglfs)
 		$(usev evdev)
@@ -89,12 +89,15 @@ pkg_setup() {
 		$(usev kms)
 		$(usev opengl)
 		$(use udev && echo libudev)
-		$(usev xcb)"
+		$(usev xcb)
+	)
 
-	QCONFIG_DEFINE="$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
-			$(use eglfs && echo QT_EGLFS)
-			$(use gles2 && echo QT_EGL)
-			$(use jpeg && echo QT_IMAGEFORMAT_JPEG)"
+	QCONFIG_DEFINE=(
+		$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
+		$(use eglfs && echo QT_EGLFS)
+		$(use gles2 && echo QT_EGL)
+		$(use jpeg && echo QT_IMAGEFORMAT_JPEG)
+	)
 
 	use ibus && QT5_TARGET_SUBDIRS+=(src/plugins/platforminputcontexts/ibus)
 	use opengl && QT5_TARGET_SUBDIRS+=(src/openglextensions)

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -79,7 +79,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="
+	QCONFIG_ADD=(
 		$(use accessibility && echo accessibility-atspi-bridge)
 		$(usev eglfs)
 		$(usev evdev)
@@ -89,12 +89,15 @@ pkg_setup() {
 		$(usev kms)
 		$(usev opengl)
 		$(use udev && echo libudev)
-		$(usev xcb)"
+		$(usev xcb)
+	)
 
-	QCONFIG_DEFINE="$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
-			$(use eglfs && echo QT_EGLFS)
-			$(use gles2 && echo QT_EGL)
-			$(use jpeg && echo QT_IMAGEFORMAT_JPEG)"
+	QCONFIG_DEFINE=(
+		$(use accessibility && echo QT_ACCESSIBILITY_ATSPI_BRIDGE || echo QT_NO_ACCESSIBILITY_ATSPI_BRIDGE)
+		$(use eglfs && echo QT_EGLFS)
+		$(use gles2 && echo QT_EGL)
+		$(use jpeg && echo QT_IMAGEFORMAT_JPEG)
+	)
 
 	use ibus && QT5_TARGET_SUBDIRS+=(src/plugins/platforminputcontexts/ibus)
 	use opengl && QT5_TARGET_SUBDIRS+=(src/openglextensions)

--- a/dev-qt/qtjsbackend/qtjsbackend-5.1.1.ebuild
+++ b/dev-qt/qtjsbackend/qtjsbackend-5.1.1.ebuild
@@ -34,7 +34,7 @@ pkg_setup() {
 src_configure() {
 	if host-is-pax; then
 		echo "QT_CONFIG -= v8snapshot" >> "${QT5_BUILD_DIR}"/.qmake.cache
-		QCONFIG_REMOVE="v8snapshot"
+		QCONFIG_REMOVE=( v8snapshot )
 	fi
 
 	qt5-build_src_configure

--- a/dev-qt/qtprintsupport/qtprintsupport-5.1.1.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.1.1.ebuild
@@ -34,7 +34,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="$(usev cups)"
+	QCONFIG_ADD=( $(usev cups) )
 
 	qt5-build_pkg_setup
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.2.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.2.9999.ebuild
@@ -34,7 +34,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="$(usev cups)"
+	QCONFIG_ADD=( $(usev cups) )
 
 	qt5-build_pkg_setup
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
@@ -34,7 +34,7 @@ QT5_TARGET_SUBDIRS=(
 )
 
 pkg_setup() {
-	QCONFIG_ADD="$(usev cups)"
+	QCONFIG_ADD=( $(usev cups) )
 
 	qt5-build_pkg_setup
 }

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -450,7 +450,7 @@ qt5_base_configure() {
 		# command line if x11-libs/cairo is built with USE=qt4 (bug 433826)
 		-no-gtkstyle
 
-		# don't build with -Werror
+		# do not build with -Werror
 		-no-warnings-are-errors
 
 		# module-specific options
@@ -506,7 +506,7 @@ qt5_install_module_qconfigs() {
 
 	# qconfig.h
 	: > "${T}"/${PN}-qconfig.h
-	for x in ${QCONFIG_DEFINE}; do
+	for x in ${QCONFIG_DEFINE[@]}; do
 		echo "#define ${x}" >> "${T}"/${PN}-qconfig.h
 	done
 	[[ -s ${T}/${PN}-qconfig.h ]] && (
@@ -516,9 +516,12 @@ qt5_install_module_qconfigs() {
 
 	# qconfig.pri
 	: > "${T}"/${PN}-qconfig.pri
-	for x in QCONFIG_ADD QCONFIG_REMOVE; do
-		[[ -n ${!x} ]] && echo "${x}=${!x}" >> "${T}"/${PN}-qconfig.pri
-	done
+
+	[[ -n ${QCONFIG_ADD[@]} ]] && echo "QCONFIG_ADD=${QCONFIG_ADD[@]}" \
+		>> "${T}"/${PN}-qconfig.pri
+	[[ -n ${QCONFIG_REMOVE[@]} ]] && echo "QCONFIG_REMOVE=${QCONFIG_REMOVE[@]}" \
+		>> "${T}"/${PN}-qconfig.pri
+
 	[[ -s ${T}/${PN}-qconfig.pri ]] && (
 		insinto "${QT5_ARCHDATADIR#${EPREFIX}}"/mkspecs/gentoo
 		doins "${T}"/${PN}-qconfig.pri


### PR DESCRIPTION
rewrite of QCONFIG_DEFINE, QCONFIG_ADD and QCONFIG_REMOVE to use array. All ebuild should be converted with this commit.

Solves gentoo bug #480654
