### PR TITLE
[dev-qt/qtcore:5] Fix errors in cmake config file

### DIFF
--- a/dev-qt/qtcore/files/fix-cmake-errors.patch
+++ b/dev-qt/qtcore/files/fix-cmake-errors.patch
@@ -1,0 +1,13 @@
+--- qtbase-opensource-src-5.2.0-beta1/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ qtbase-opensource-src-5.2.0-beta1/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+@@ -185,7 +185,9 @@
+         list(APPEND Qt5$${CMAKE_MODULE_NAME}_EXECUTABLE_COMPILE_FLAGS ${Qt5${_module_dep}_EXECUTABLE_COMPILE_FLAGS})
+     endforeach()
+     list(REMOVE_DUPLICATES Qt5$${CMAKE_MODULE_NAME}_INCLUDE_DIRS)
+-    list(REMOVE_DUPLICATES Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS)
++    if(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS)
++        list(REMOVE_DUPLICATES Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS)
++    endif()
+     list(REMOVE_DUPLICATES Qt5$${CMAKE_MODULE_NAME}_DEFINITIONS)
+     list(REMOVE_DUPLICATES Qt5$${CMAKE_MODULE_NAME}_COMPILE_DEFINITIONS)
+     if (Qt5$${CMAKE_MODULE_NAME}_EXECUTABLE_COMPILE_FLAGS)

--- a/dev-qt/qtcore/qtcore-5.2.0_beta1.ebuild
+++ b/dev-qt/qtcore/qtcore-5.2.0_beta1.ebuild
@@ -44,6 +44,12 @@ pkg_setup() {
 	qt5-build_pkg_setup
 }
 
+src_prepare() {
+	epatch "${FILESDIR}"/fix-cmake-errors.patch
+
+	qt5-build_src_prepare
+}
+
 src_configure() {
 	local myconf=(
 		$(qt_use glib)


### PR DESCRIPTION
The dev-qt/qtcore-5.2.0_beta1 ebuild previously installed a cmake configuration file (/usr/lib64/cmake/Qt5Core/Qt5CoreConfig.cmake) which caused cmake builds to fail with the following error (from emerge =dev-util/cmake-2.8.11.2):

CMake Error at /usr/lib64/cmake/Qt5Core/Qt5CoreConfig.cmake:116 (list):
  list sub-command REMOVE_DUPLICATES requires list to be present.
Call Stack (most recent call first):
  Tests/RunCMake/CMakeLists.txt:80 (find_package)

This patch alters the Qt5CoreConfig.cmake file to only REMOVE_DUPLICATES when the Qt5Core_PRIVATE_INCLUDE_DIRS variable is set & nonempty.
