### PR TITLE
Fix building qt*-*.9999

### DIFF
--- a/eclass/qt4-build.eclass
+++ b/eclass/qt4-build.eclass
@@ -36,10 +36,10 @@ case ${QT4_BUILD_TYPE} in
 			"https://git.gitorious.org/qt/qt.git"
 		)
 		EGIT_BRANCH=${PV%.9999}
-		MY_P=${P}
 		;;
 	release)
 		SRC_URI="http://download.qt-project.org/official_releases/qt/${PV%.*}/${PV}/${MY_P}.tar.gz"
+		S=${WORKDIR}/${MY_P}
 		;;
 esac
 
@@ -53,8 +53,6 @@ DEPEND="virtual/pkgconfig"
 if [[ ${QT4_BUILD_TYPE} == live ]]; then
 	DEPEND+=" dev-lang/perl"
 fi
-
-S=${WORKDIR}/${MY_P}
 
 # @FUNCTION: qt4-build_pkg_setup
 # @DESCRIPTION:


### PR DESCRIPTION
Without this fix, it is impossible to build qtcore-4.8.9999 (and very likely all other 4.8.9999 and .9999 Qt components), as this makes $WORKDIR being

```
/var/tmp/portage/dev-qt/qtcore-4.8.9999/work/qt-everywhere-opensource-src-4.8.9999
```

instead of

```
/var/tmp/portage/dev-qt/qtcore-4.8.9999/work/qtcore-4.8.9999
```

By resetting `$MY_P` to `$P` for .9999 ebuilds, everything should work again.

Please review first - I'm not sure how Qt 5.x ebuilds might be affected here.
