### PR TITLE
[dev-qt/qtwebkit:5] Respect C(XX)FLAGS

### DIFF
--- a/dev-qt/qtwebkit/qtwebkit-5.2.1.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -67,6 +67,10 @@ pkg_setup() {
 src_prepare() {
 	# bug 458222
 	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
+
+	# bug 490254
+	echo "QMAKE_CFLAGS=\"${CFLAGS}\"" >> .qmake.conf
+	echo "QMAKE_CXXFLAGS=\"${CXXFLAGS}\"" >> .qmake.conf
 
 	qt5-build_src_prepare
 }


### PR DESCRIPTION
Flags were loaded from /usr/lib64/qt5/mkspecs/qmodule.pri before. This overwrites them here before QtWebkit does its own additions to C(XX)FLAGS.

I'm not really convinced that this is the best solution but I was not able to figure out a better alternative. (E.g. it would be nice to have a kind of "file overlay" on /usr/lib64/qt5/mkspecs/qmodule.pri where we have specified the correct C(XX)FLAGS)

This has to be done for every package that is a Qt module but not part of the qtbase tarball.

Fixes https://bugs.gentoo.org/show_bug.cgi?id=490254 for qtwebkit:5
