### PR TITLE
[dev-qt/qtgui:5] kms USE flag depends on evdev

### DIFF
--- a/dev-qt/qtgui/qtgui-5.2.1.ebuild
+++ b/dev-qt/qtgui/qtgui-5.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -22,7 +22,7 @@ IUSE="accessibility eglfs evdev gif gles2 +glib harfbuzz ibus jpeg kms opengl +p
 REQUIRED_USE="
 	eglfs? ( evdev gles2 )
 	gles2? ( opengl )
-	kms? ( gles2 )
+	kms? ( evdev gles2 )
 "
 
 RDEPEND="

--- a/dev-qt/qtgui/qtgui-5.3.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.3.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -22,7 +22,7 @@ IUSE="accessibility eglfs evdev gif gles2 +glib harfbuzz ibus jpeg kms opengl +p
 REQUIRED_USE="
 	eglfs? ( evdev gles2 )
 	gles2? ( opengl )
-	kms? ( gles2 )
+	kms? ( evdev gles2 )
 "
 
 RDEPEND="

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -22,7 +22,7 @@ IUSE="accessibility eglfs evdev gif gles2 +glib harfbuzz ibus jpeg kms opengl +p
 REQUIRED_USE="
 	eglfs? ( evdev gles2 )
 	gles2? ( opengl )
-	kms? ( gles2 )
+	kms? ( evdev gles2 )
 "
 
 RDEPEND="


### PR DESCRIPTION
- Fixes bug https://bugs.gentoo.org/show_bug.cgi?id=504182
