### PR TITLE
[dev-qt/qtwebkit:5] Remove automagic in dependencies

### DIFF
--- a/dev-qt/qtwebkit/files/qtwebkit-5.2.1-disable-gstreamer.patch
+++ b/dev-qt/qtwebkit/files/qtwebkit-5.2.1-disable-gstreamer.patch
@@ -1,0 +1,15 @@
+--- Tools/qmake/mkspecs/features/features.prf	2014-03-19 18:35:47.795676444 +0000
++++ Tools/qmake/mkspecs/features/features.prf	2014-03-19 18:36:38.602433220 +0000
+@@ -99,12 +99,6 @@
+ 
+     # HTML5 Media Support for builds with GStreamer
+     unix:!mac:!contains(QT_CONFIG, no-pkg-config) {
+-        packagesExist("glib-2.0 gio-2.0 gstreamer-1.0 gstreamer-plugins-base-1.0") {
+-            WEBKIT_CONFIG += video use_gstreamer
+-        } else: packagesExist("glib-2.0 gio-2.0 \'gstreamer-0.10 >= 0.10.30\' \'gstreamer-plugins-base-0.10 >= 0.10.30\'") {
+-            WEBKIT_CONFIG += video use_gstreamer use_gstreamer010
+-        }
+-        use?(gstreamer): WEBKIT_CONFIG += use_native_fullscreen_video
+     }
+ 
+     !enable?(video):qtHaveModule(multimediawidgets) {

--- a/dev-qt/qtwebkit/qtwebkit-5.2.1.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -65,6 +65,16 @@ pkg_setup() {
 }
 
 src_prepare() {
+	use gstreamer || epatch "${FILESDIR}/${PN}-${PV}-disable-gstreamer.patch"
+	use libxml2 || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' Tools/qmake/mkspecs/features/features.prf || die
+	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' Tools/qmake/mkspecs/features/features.prf || die
+	use opengl || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' Tools/qmake/mkspecs/features/features.prf || die
+	use qml || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' Source/QtWebKit.pro || die
+	use udev || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' Tools/qmake/mkspecs/features/features.prf || die
+	use webp || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' Tools/qmake/mkspecs/features/features.prf || die
+	use widgets || sed -i -e '/SUBDIRS += webkitwidgets/d' Source/QtWebKit.pro || die
+	use xslt || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' Tools/qmake/mkspecs/features/features.prf || die
+
 	# bug 458222
 	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
 

--- a/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -65,6 +65,16 @@ pkg_setup() {
 }
 
 src_prepare() {
+	use gstreamer || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	use libxml2 || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' Tools/qmake/mkspecs/features/features.prf || die
+	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' Tools/qmake/mkspecs/features/features.prf || die
+	use opengl || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' Tools/qmake/mkspecs/features/features.prf || die
+	use qml || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' Source/QtWebKit.pro || die
+	use udev || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' Tools/qmake/mkspecs/features/features.prf || die
+	use webp || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' Tools/qmake/mkspecs/features/features.prf || die
+	use widgets || sed -i -e '/SUBDIRS += webkitwidgets/d' Source/QtWebKit.pro || die
+	use xslt || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' Tools/qmake/mkspecs/features/features.prf || die
+
 	# bug 458222
 	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
 

--- a/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -65,6 +65,16 @@ pkg_setup() {
 }
 
 src_prepare() {
+	use gstreamer || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	use libxml2 || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' Tools/qmake/mkspecs/features/features.prf || die
+	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' Tools/qmake/mkspecs/features/features.prf || die
+	use opengl || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' Tools/qmake/mkspecs/features/features.prf || die
+	use qml || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' Source/QtWebKit.pro || die
+	use udev || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' Tools/qmake/mkspecs/features/features.prf || die
+	use webp || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' Tools/qmake/mkspecs/features/features.prf || die
+	use widgets || sed -i -e '/SUBDIRS += webkitwidgets/d' Source/QtWebKit.pro || die
+	use xslt || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' Tools/qmake/mkspecs/features/features.prf || die
+
 	# bug 458222
 	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
 


### PR DESCRIPTION
This fixes https://bugs.gentoo.org/show_bug.cgi?id=457174
