### PR TITLE
[qt5] Download development release if beta is not numbered

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -40,7 +40,7 @@ case ${PV} in
 		QT5_BUILD_TYPE="live"
 		EGIT_BRANCH="stable"
 		;;
-	*_alpha?|*_beta?|*_rc?)
+	*_alpha*|*_beta*|*_rc*)
 		# pre-releases
 		QT5_BUILD_TYPE="release"
 		MY_P="${QT5_MODULE}-opensource-src-${PV/_/-}"


### PR DESCRIPTION
e.g. current Qt 5.3.0 beta has no number, it's just a beta
