### PR TITLE
Add missing dependency on Qxt to make it build

### DIFF
--- a/x11-terms/qterminal/qterminal-9999.ebuild
+++ b/x11-terms/qterminal/qterminal-9999.ebuild
@@ -16,6 +16,7 @@ KEYWORDS=""
 IUSE="debug"
 
 DEPEND="dev-qt/qtgui:4
+	x11-libs/libqxt
 	x11-libs/qtermwidget"
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
The build system now looks for system level Qxt installation by default. 
