### PR TITLE
[dev-qt/qtdeclarative] 5.2.1 is dependent on the OpenGL backend in QtGui

### DIFF
--- a/dev-qt/qtdeclarative/metadata.xml
+++ b/dev-qt/qtdeclarative/metadata.xml
@@ -5,6 +5,7 @@
 	<use>
 		<flag name="exceptions">Add support for exceptions - like catching them
 			inside the event loop (recommended by Nokia)</flag>
+		<flag name="gles2">Use OpenGL ES 2.0 instead of desktop OpenGL</flag>
 		<flag name="localstorage">Build the LocalStorage import for
 			QtQuick (requires QtSql)</flag>
 		<flag name="qt3support">Enable the Qt3Support libraries for Qt4. Note that

--- a/dev-qt/qtdeclarative/qtdeclarative-5.2.1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
@@ -14,11 +14,11 @@ else
 	KEYWORDS="~amd64"
 fi
 
-IUSE="+localstorage +widgets +xml"
+IUSE="+localstorage +widgets +xml gles2"
 
 DEPEND="
 	>=dev-qt/qtcore-${PV}:5[debug=]
-	>=dev-qt/qtgui-${PV}:5[debug=,opengl]
+	>=dev-qt/qtgui-${PV}:5[debug=,gles2=,opengl]
 	>=dev-qt/qtnetwork-${PV}:5[debug=]
 	>=dev-qt/qttest-${PV}:5[debug=]
 	localstorage? ( >=dev-qt/qtsql-${PV}:5[debug=] )


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=504322
