### PR TITLE
[dev-qt/qtgui] Bump libxkbcommon dependency

### DIFF
--- a/dev-qt/qtgui/qtgui-5.3.0_beta.ebuild
+++ b/dev-qt/qtgui/qtgui-5.3.0_beta.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 		>=x11-libs/libXi-1.6
 		x11-libs/libXrender
 		>=x11-libs/libxcb-1.10[xkb]
-		>=x11-libs/libxkbcommon-0.2.0
+		>=x11-libs/libxkbcommon-0.4.1
 		x11-libs/xcb-util-image
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil

--- a/dev-qt/qtgui/qtgui-5.3.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.3.9999.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 		>=x11-libs/libXi-1.6
 		x11-libs/libXrender
 		>=x11-libs/libxcb-1.10[xkb]
-		>=x11-libs/libxkbcommon-0.2.0
+		>=x11-libs/libxkbcommon-0.4.1
 		x11-libs/xcb-util-image
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 		>=x11-libs/libXi-1.6
 		x11-libs/libXrender
 		>=x11-libs/libxcb-1.10[xkb]
-		>=x11-libs/libxkbcommon-0.2.0
+		>=x11-libs/libxkbcommon-0.4.1
 		x11-libs/xcb-util-image
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil


### PR DESCRIPTION
Now that libxkcommon-0.4.1 is in the tree, use it instead of built-in variant shipped with Qt.

Package-Manager: portage-2.2.10
