### PR TITLE
[dev-qt/qtwayland] Add depency on egl

### DIFF
--- a/dev-qt/qtwayland/qtwayland-5.3.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.3.9999.ebuild
@@ -20,7 +20,7 @@ IUSE="qml wayland-compositor"
 DEPEND="
 	>=dev-libs/wayland-1.3.0
 	>=dev-qt/qtcore-${PV}:5[debug=]
-	>=dev-qt/qtgui-${PV}:5[debug=,opengl]
+	>=dev-qt/qtgui-${PV}:5[debug=,egl,opengl]
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -20,7 +20,7 @@ IUSE="qml wayland-compositor"
 DEPEND="
 	>=dev-libs/wayland-1.3.0
 	>=dev-qt/qtcore-${PV}:5[debug=]
-	>=dev-qt/qtgui-${PV}:5[debug=,opengl]
+	>=dev-qt/qtgui-${PV}:5[debug=,egl,opengl]
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
qtwayland depends on egl, add this as a dependency on qtgui. Build log without egl: https://gist.github.com/xhochy/dd0f6b55621f0743660e 
