### PR TITLE
[dev-qt/qtwebkit:5] Add printsupport USE flag

### DIFF
--- a/dev-qt/qtwebkit/metadata.xml
+++ b/dev-qt/qtwebkit/metadata.xml
@@ -8,6 +8,7 @@
 		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer</pkg></flag>
 		<flag name="libxml2">Use <pkg>dev-libs/libxml2</pkg> for XML parsing</flag>
 		<flag name="multimedia">Enable HTML5 audio/video support via <pkg>dev-qt/qtmultimedia</pkg></flag>
+		<flag name="printsupport">Enable printing via <pkg>dev-qt/qtprintsupport</pkg></flag>
 		<flag name="qml">Build QML/QtQuick bindings</flag>
 		<flag name="webp">Add support for WebP image format</flag>
 		<flag name="widgets">Build various things that depend on <pkg>dev-qt/qtwidgets</pkg>,

--- a/dev-qt/qtwebkit/qtwebkit-5.3.0_rc.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.0_rc.ebuild
@@ -16,9 +16,9 @@ else
 	KEYWORDS="~amd64"
 fi
 
-# TODO: qtprintsupport, qttestlib, geolocation, orientation/sensors
+# TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl qml udev webp widgets xslt"
+IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xslt"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -42,6 +42,7 @@ RDEPEND="
 	libxml2? ( dev-libs/libxml2:2 )
 	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
+	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
 	udev? ( virtual/udev )
 	webp? ( media-libs/libwebp:0= )
@@ -64,22 +65,24 @@ pkg_setup() {
 }
 
 src_prepare() {
-	use gstreamer  || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
-	use libxml2    || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
+	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
+	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use opengl     || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
+	use opengl       || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use qml        || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
+	use printsupport || sed -i -e '/WEBKIT_CONFIG += have_qtprintsupport/d' \
+		Tools/qmake/mkspecs/features/features.prf || die
+	use qml          || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
 		Source/QtWebKit.pro || die
-	use udev       || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
+	use udev         || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use webp       || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
+	use webp         || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use widgets    || sed -i -e '/SUBDIRS += webkitwidgets/d' \
+	use widgets      || sed -i -e '/SUBDIRS += webkitwidgets/d' \
 		Source/QtWebKit.pro || die
-	use xslt       || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
+	use xslt         || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 
 	# bug 458222

--- a/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
@@ -16,9 +16,9 @@ else
 	KEYWORDS="~amd64"
 fi
 
-# TODO: qtprintsupport, qttestlib, geolocation, orientation/sensors
+# TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl qml udev webp widgets xslt"
+IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xslt"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -42,6 +42,7 @@ RDEPEND="
 	libxml2? ( dev-libs/libxml2:2 )
 	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
+	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
 	udev? ( virtual/udev )
 	webp? ( media-libs/libwebp:0= )
@@ -64,22 +65,24 @@ pkg_setup() {
 }
 
 src_prepare() {
-	use gstreamer  || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
-	use libxml2    || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
+	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
+	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use opengl     || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
+	use opengl       || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use qml        || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
+	use printsupport || sed -i -e '/WEBKIT_CONFIG += have_qtprintsupport/d' \
+		Tools/qmake/mkspecs/features/features.prf || die
+	use qml          || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
 		Source/QtWebKit.pro || die
-	use udev       || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
+	use udev         || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use webp       || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
+	use webp         || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use widgets    || sed -i -e '/SUBDIRS += webkitwidgets/d' \
+	use widgets      || sed -i -e '/SUBDIRS += webkitwidgets/d' \
 		Source/QtWebKit.pro || die
-	use xslt       || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
+	use xslt         || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 
 	# bug 458222

--- a/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
@@ -16,9 +16,9 @@ else
 	KEYWORDS="~amd64"
 fi
 
-# TODO: qtprintsupport, qttestlib, geolocation, orientation/sensors
+# TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl qml udev webp widgets xslt"
+IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xslt"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -42,6 +42,7 @@ RDEPEND="
 	libxml2? ( dev-libs/libxml2:2 )
 	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
+	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
 	udev? ( virtual/udev )
 	webp? ( media-libs/libwebp:0= )
@@ -64,22 +65,24 @@ pkg_setup() {
 }
 
 src_prepare() {
-	use gstreamer  || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
-	use libxml2    || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
+	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use multimedia || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
+	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use opengl     || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
+	use opengl       || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use qml        || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
+	use printsupport || sed -i -e '/WEBKIT_CONFIG += have_qtprintsupport/d' \
+		Tools/qmake/mkspecs/features/features.prf || die
+	use qml          || sed -i -e '/have?(QTQUICK): SUBDIRS += declarative/d' \
 		Source/QtWebKit.pro || die
-	use udev       || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
+	use udev         || sed -i -e '/linux: WEBKIT_CONFIG += gamepad/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use webp       || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
+	use webp         || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
-	use widgets    || sed -i -e '/SUBDIRS += webkitwidgets/d' \
+	use widgets      || sed -i -e '/SUBDIRS += webkitwidgets/d' \
 		Source/QtWebKit.pro || die
-	use xslt       || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
+	use xslt         || sed -i -e '/config_libxslt: WEBKIT_CONFIG += xslt/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 
 	# bug 458222


### PR DESCRIPTION
This commit updates the =dev-qt/qtwebkit-5.3.0_rc ebuild to allow for
enabling/disabling of its qtprintsupport dependency.

I have verified that the ebuild works correctly with this patch on ~amd64:

Building with USE="-printsupport":

```
$ emerge -pv dev-qt/qtwebkit:5

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild   R   ~] dev-qt/qtwebkit-5.3.0_rc:5::local-qt-dev  USE="multimedia opengl udev widgets
-debug -gstreamer -libxml2 -printsupport -qml {-test} -webp -xslt" 0 kB

Total: 1 package (1 reinstall), Size of downloads: 0 kB

$ ldd /usr/lib64/libQt5WebKit*.so.* | grep PrintSupport
```

Building with USE="printsupport":

```
$ emerge -pv qtwebkit:5

These are the packages that would be merged, in order:

Calculating dependencies... done!
[ebuild  N    ~] dev-qt/qtprintsupport-5.3.0_rc:5::local-qt-dev  USE="cups -debug {-test}" 0 kB
[ebuild   R   ~] dev-qt/qtwebkit-5.3.0_rc:5::local-qt-dev  USE="multimedia opengl printsupport*
udev widgets -debug -gstreamer -libxml2 -qml {-test} -webp -xslt" 0 kB

Total: 2 packages (1 new, 1 reinstall), Size of downloads: 0 kB

$ ldd /usr/lib64/libQt5WebKit*.so.* | grep PrintSupport
        libQt5PrintSupport.so.5 => /usr/lib64/libQt5PrintSupport.so.5 (0x00007f8c526ef000)
        libQt5PrintSupport.so.5 => /usr/lib64/libQt5PrintSupport.so.5 (0x00007effb6920000)
        libQt5PrintSupport.so.5 => /usr/lib64/libQt5PrintSupport.so.5 (0x00007feffa9a9000)
```
