### PR TITLE
[dev-qt/qtwidgets:5] Remove accessible plugin from ebuild

### DIFF
--- a/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
@@ -27,5 +27,4 @@ RDEPEND="${DEPEND}"
 QT5_TARGET_SUBDIRS=(
 	src/tools/uic
 	src/widgets
-	src/plugins/accessible
 )


### PR DESCRIPTION
Upstream has made the accessibility plugin part of the normal widgets
code, instead of being a separate plugin. This fixes build failures
stating that "src/plugins/accessible" cannot be found when building with
upstream commit eaee2bd0.

Note that the git tree dev-qt/qtwidgets-5.3.9999 builds does NOT include this commit, so that ebuild does not need to be changed.
