### PR TITLE
[dev-qt/qtgui:5] Add platformheaders target subdir

### DIFF
--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -71,6 +71,7 @@ PDEPEND="
 
 QT5_TARGET_SUBDIRS=(
 	src/gui
+	src/platformheaders
 	src/platformsupport
 	src/plugins/generic
 	src/plugins/imageformats


### PR DESCRIPTION
The dev-qt/qtgui-5.9999 ebuild was failing to build, complaining that
QtPlatformHeaders/qxcbwindowfunctions.h couldn't be found. Upstream
commit 5c28747 added this header file, so we need to add its subdir to
the ebuild as well so it gets installed properly.

According to xhochy in #gentoo-qt, this issue doesn't affect the 5.3.9999 ebuild (probably that tree doesn't include the aforementioned upstream commit), so it doesn't need to be changed.

We could do this in pkg_setup() instead, only if the xcb USE flag is set, however since this subdir only installs a small number of header files, and other parts of the build may depend on them (e.g. this subdir also includes qeglnativecontext.h and qglxnativecontext.h), I would say it's worth always building them.
