### PR TITLE
[eclass] Built Qt5 by default with -no-egl

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -481,6 +481,9 @@ qt5_base_configure() {
 		# requires GNU ld >= 2.18
 		-reduce-relocations
 
+		# disable EGL by default, override in qtgui
+		-no-egl
+
 		# disable all SQL drivers by default, override in qtsql
 		-no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc
 		-no-sql-psql -no-sql-sqlite -no-sql-sqlite2 -no-sql-tds


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/show_bug.cgi?id=510556 for fresh installs.
