### PR TITLE
[dev-qt/qtwebkit] Add subslot dependency for icu

### DIFF
--- a/dev-qt/qtwebkit/qtwebkit-5.3.0.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.0.ebuild
@@ -22,6 +22,7 @@ IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xsl
 
 RDEPEND="
 	dev-db/sqlite:3
+	dev-libs/icu:=
 	>=dev-qt/qtcore-${PV}:5[debug=,icu]
 	>=dev-qt/qtgui-${PV}:5[debug=]
 	>=dev-qt/qtnetwork-${PV}:5[debug=]

--- a/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
@@ -22,6 +22,7 @@ IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xsl
 
 RDEPEND="
 	dev-db/sqlite:3
+	dev-libs/icu:=
 	>=dev-qt/qtcore-${PV}:5[debug=,icu]
 	>=dev-qt/qtgui-${PV}:5[debug=]
 	>=dev-qt/qtnetwork-${PV}:5[debug=]

--- a/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
@@ -22,6 +22,7 @@ IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp widgets xsl
 
 RDEPEND="
 	dev-db/sqlite:3
+	dev-libs/icu:=
 	>=dev-qt/qtcore-${PV}:5[debug=,icu]
 	>=dev-qt/qtgui-${PV}:5[debug=]
 	>=dev-qt/qtnetwork-${PV}:5[debug=]


### PR DESCRIPTION
QtWebkit links directly to icu (e.g. `libicui18n.so.51`) so we need to rebuild it on an icu slot update.

```
% lddtree /usr/lib64/libQt5WebKit.so.5.3.1
libQt5WebKit.so.5.3.1 => /usr/lib64/libQt5WebKit.so.5.3.1 (interpreter => none)
    libz.so.1 => /lib64/libz.so.1
    libjpeg.so.62 => /usr/lib64/libjpeg.so.62
    libpng16.so.16 => /usr/lib64/libpng16.so.16
    libX11.so.6 => /usr/lib64/libX11.so.6
        libxcb.so.1 => /usr/lib64/libxcb.so.1
            libXau.so.6 => /usr/lib64/libXau.so.6
            libXdmcp.so.6 => /usr/lib64/libXdmcp.so.6
        libdl.so.2 => /lib64/libdl.so.2
            ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2
    libxslt.so.1 => /usr/lib64/libxslt.so.1
    libxml2.so.2 => /usr/lib64/libxml2.so.2
        libicuuc.so.52 => /usr/lib64/libicuuc.so.52
            libicudata.so.52 => /usr/lib64/libicudata.so.52
            libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.0/libgcc_s.so.1
    libm.so.6 => /lib64/libm.so.6
    libsqlite3.so.0 => /usr/lib64/libsqlite3.so.0
    libicui18n.so.51 => /usr/lib64/libicui18n.so.51
    libicuuc.so.51 => /usr/lib64/libicuuc.so.51
        libicudata.so.51 => /usr/lib64/libicudata.so.51
    libQt5Network.so.5 => /usr/lib64/libQt5Network.so.5
        libssl.so.1.0.0 => /usr/lib64/libssl.so.1.0.0
            libkrb5.so.3 => /usr/lib64/libkrb5.so.3
                libcom_err.so.2 => /lib64/libcom_err.so.2
                libkrb5support.so.0 => /usr/lib64/libkrb5support.so.0
                libkeyutils.so.1 => /lib64/libkeyutils.so.1
                libresolv.so.2 => /lib64/libresolv.so.2
            libk5crypto.so.3 => /usr/lib64/libk5crypto.so.3
        libcrypto.so.1.0.0 => /usr/lib64/libcrypto.so.1.0.0
    libQt5Core.so.5 => /usr/lib64/libQt5Core.so.5
        libicui18n.so.52 => /usr/lib64/libicui18n.so.52
        libpcre16.so.0 => /usr/lib64/libpcre16.so.0
        libglib-2.0.so.0 => /usr/lib64/libglib-2.0.so.0
        librt.so.1 => /lib64/librt.so.1
    libpthread.so.0 => /lib64/libpthread.so.0
    libQt5Gui.so.5 => /usr/lib64/libQt5Gui.so.5
        libGL.so.1 => /usr/lib64/libGL.so.1
            libglapi.so.0 => /usr/lib64/libglapi.so.0
            libXext.so.6 => /usr/lib64/libXext.so.6
            libXdamage.so.1 => /usr/lib64/libXdamage.so.1
            libXfixes.so.3 => /usr/lib64/libXfixes.so.3
            libX11-xcb.so.1 => /usr/lib64/libX11-xcb.so.1
            libxcb-glx.so.0 => /usr/lib64/libxcb-glx.so.0
            libxcb-dri2.so.0 => /usr/lib64/libxcb-dri2.so.0
            libxcb-dri3.so.0 => /usr/lib64/libxcb-dri3.so.0
            libxcb-present.so.0 => /usr/lib64/libxcb-present.so.0
            libxcb-sync.so.1 => /usr/lib64/libxcb-sync.so.1
            libxshmfence.so.1 => /usr/lib64/libxshmfence.so.1
            libXxf86vm.so.1 => /usr/lib64/libXxf86vm.so.1
            libdrm.so.2 => /usr/lib64/libdrm.so.2
    libQt5Sql.so.5 => /usr/lib64/libQt5Sql.so.5
    libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.0/libstdc++.so.6
    libc.so.6 => /lib64/libc.so.6
```
