### PR TITLE
[x11-misc/sddm] Add user/group creation

### DIFF
--- a/x11-misc/sddm/sddm-9999.ebuild
+++ b/x11-misc/sddm/sddm-9999.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 EAPI=5
-inherit cmake-utils git-r3 toolchain-funcs
+inherit cmake-utils git-r3 toolchain-funcs user
 
 DESCRIPTION="Simple Desktop Display Manager"
 HOMEPAGE="https://github.com/sddm/sddm"
@@ -47,4 +47,9 @@ src_configure() {
 		$(cmake-utils_use_use qt5 QT5)
 	)
 	cmake-utils_src_configure
+}
+
+pkg_setup() {
+	enewgroup ${PN}
+	enewuser ${PN} -1 -1 /var/lib/sddm ${PN}
 }


### PR DESCRIPTION
Upstream introduced support for running SDDM as non-root user in
https://github.com/sddm/sddm/commit/484395d23f2cdbde9df5d1efb25d5d2751b43aa9

Package-Manager: portage-2.2.10
