### PR TITLE
[x11-misc/sddm] Also add the 'sddm' user to the 'video' group

### DIFF
--- a/x11-misc/sddm/sddm-9999.ebuild
+++ b/x11-misc/sddm/sddm-9999.ebuild
@@ -51,5 +51,5 @@ src_configure() {
 
 pkg_setup() {
 	enewgroup ${PN}
-	enewuser ${PN} -1 -1 /var/lib/sddm ${PN}
+	enewuser ${PN} -1 -1 /var/lib/sddm ${PN} video
 }


### PR DESCRIPTION
The 'sddm' user should be a member of the 'video' group, as
sddm-greeter's UI is rendered using QML utilizing GL

Package-Manager: portage-2.2.10
