### PR TITLE
gnupg has moved to git and svn no longer responds

### DIFF
--- a/app-crypt/pinentry/pinentry-9999.ebuild
+++ b/app-crypt/pinentry/pinentry-9999.ebuild
@@ -9,7 +9,6 @@ inherit autotools multilib eutils flag-o-matic git-r3
 DESCRIPTION="Collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol"
 HOMEPAGE="http://www.gnupg.org/aegypten/"
 EGIT_REPO_URI="git://git.gnupg.org/pinentry.git"
-EGIT_BRANCH="master"
 
 LICENSE="GPL-2"
 KEYWORDS=""


### PR DESCRIPTION
had an extraneous git clone in the repo uri on the first pull request.
