### PR TITLE
[dev-qt/qtwidgets] cherry pick systray improvement from Qt 5.4

### DIFF
--- a/dev-qt/qtwidgets/files/qtwidgets-5.3.1-prefer-qpa.patch
+++ b/dev-qt/qtwidgets/files/qtwidgets-5.3.1-prefer-qpa.patch
@@ -1,0 +1,343 @@
+From f1ee10f81ac18789e9a7dc715b464415ba2bc2b8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Gr=C3=A4=C3=9Flin?= <mgraesslin@kde.org>
+Date: Wed, 19 Feb 2014 11:01:44 +0100
+Subject: [PATCH] Prefer QPA implementation in qsystemtrayicon_x11 if available
+
+In order to have the possibility to provide a custom QSystemTrayIcon
+implementation in the platform theme instead of the X11 xembed based
+one, the qpa implementation needs to be called. This was not possible
+as qpa and x11 implementation were compile time mutual exclusive.
+
+This change moves the qpa implementation in the shared part and the
+methods in qsystemtrayicon_qpa just delegate to them. In addition the
+_x11 part tries to create a QPlatformSystemTrayIcon through the
+platform theme and if that succeeds the implementation prefers the qpa
+variant and delegates to the same methods.
+
+Change-Id: I6b33acac63524a77ebdce39af6eb74666f8c7561
+Reviewed-by: Kevin Krammer <kevin.krammer@kdab.com>
+Reviewed-by: Friedemann Kleint <Friedemann.Kleint@digia.com>
+Reviewed-by: Paul Olav Tvete <paul.tvete@digia.com>
+---
+ src/widgets/util/qsystemtrayicon.cpp     |   68 ++++++++++++++++++++++++++++++
+ src/widgets/util/qsystemtrayicon_p.h     |    9 ++++
+ src/widgets/util/qsystemtrayicon_qpa.cpp |   51 ++++------------------
+ src/widgets/util/qsystemtrayicon_x11.cpp |   40 +++++++++++++++++-
+ 4 files changed, 126 insertions(+), 42 deletions(-)
+
+diff --git a/src/widgets/util/qsystemtrayicon.cpp b/src/widgets/util/qsystemtrayicon.cpp
+index f1a69e6..fa318f3 100644
+--- a/src/widgets/util/qsystemtrayicon.cpp
++++ b/src/widgets/util/qsystemtrayicon.cpp
+@@ -672,6 +672,74 @@ void QBalloonTip::timerEvent(QTimerEvent *e)
+     QWidget::timerEvent(e);
+ }
+ 
++//////////////////////////////////////////////////////////////////////
++void QSystemTrayIconPrivate::install_sys_qpa()
++{
++    qpa_sys->init();
++    QObject::connect(qpa_sys, SIGNAL(activated(QPlatformSystemTrayIcon::ActivationReason)),
++                     q_func(), SLOT(_q_emitActivated(QPlatformSystemTrayIcon::ActivationReason)));
++    QObject::connect(qpa_sys, &QPlatformSystemTrayIcon::messageClicked,
++                     q_func(), &QSystemTrayIcon::messageClicked);
++    updateMenu_sys();
++    updateIcon_sys();
++    updateToolTip_sys();
++}
++
++void QSystemTrayIconPrivate::remove_sys_qpa()
++{
++    qpa_sys->cleanup();
++}
++
++QRect QSystemTrayIconPrivate::geometry_sys_qpa() const
++{
++    return qpa_sys->geometry();
++}
++
++void QSystemTrayIconPrivate::updateIcon_sys_qpa()
++{
++    qpa_sys->updateIcon(icon);
++}
++
++void QSystemTrayIconPrivate::updateMenu_sys_qpa()
++{
++    if (menu) {
++        if (!menu->platformMenu()) {
++            QPlatformMenu *platformMenu = qpa_sys->createMenu();
++            if (platformMenu)
++                menu->setPlatformMenu(platformMenu);
++        }
++        qpa_sys->updateMenu(menu->platformMenu());
++    }
++}
++
++void QSystemTrayIconPrivate::updateToolTip_sys_qpa()
++{
++    qpa_sys->updateToolTip(toolTip);
++}
++
++void QSystemTrayIconPrivate::showMessage_sys_qpa(const QString &message,
++                                                 const QString &title,
++                                                 QSystemTrayIcon::MessageIcon icon,
++                                                 int msecs)
++{
++    QIcon notificationIcon;
++    switch (icon) {
++    case QSystemTrayIcon::Information:
++        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation);
++        break;
++    case QSystemTrayIcon::Warning:
++        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
++        break;
++    case QSystemTrayIcon::Critical:
++        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical);
++        break;
++    default:
++        break;
++    }
++    qpa_sys->showMessage(message, title, notificationIcon,
++                     static_cast<QPlatformSystemTrayIcon::MessageIcon>(icon), msecs);
++}
++
+ QT_END_NAMESPACE
+ 
+ #endif // QT_NO_SYSTEMTRAYICON
+diff --git a/src/widgets/util/qsystemtrayicon_p.h b/src/widgets/util/qsystemtrayicon_p.h
+index 211ef30..317664a 100644
+--- a/src/widgets/util/qsystemtrayicon_p.h
++++ b/src/widgets/util/qsystemtrayicon_p.h
+@@ -98,6 +98,15 @@ public:
+     QSystemTrayIconSys *sys;
+     QPlatformSystemTrayIcon *qpa_sys;
+     bool visible;
++
++private:
++    void install_sys_qpa();
++    void remove_sys_qpa();
++    void updateIcon_sys_qpa();
++    void updateToolTip_sys_qpa();
++    void updateMenu_sys_qpa();
++    QRect geometry_sys_qpa() const;
++    void showMessage_sys_qpa(const QString &msg, const QString &title, QSystemTrayIcon::MessageIcon icon, int secs);
+ };
+ 
+ class QBalloonTip : public QWidget
+diff --git a/src/widgets/util/qsystemtrayicon_qpa.cpp b/src/widgets/util/qsystemtrayicon_qpa.cpp
+index f98aeaf..045641c 100644
+--- a/src/widgets/util/qsystemtrayicon_qpa.cpp
++++ b/src/widgets/util/qsystemtrayicon_qpa.cpp
+@@ -65,28 +65,20 @@ QSystemTrayIconPrivate::~QSystemTrayIconPrivate()
+ 
+ void QSystemTrayIconPrivate::install_sys()
+ {
+-    if (qpa_sys) {
+-        qpa_sys->init();
+-        QObject::connect(qpa_sys, SIGNAL(activated(QPlatformSystemTrayIcon::ActivationReason)),
+-                         q_func(), SLOT(_q_emitActivated(QPlatformSystemTrayIcon::ActivationReason)));
+-        QObject::connect(qpa_sys, SIGNAL(messageClicked()),
+-                         q_func(), SIGNAL(messageClicked()));
+-        updateMenu_sys();
+-        updateIcon_sys();
+-        updateToolTip_sys();
+-    }
++    if (qpa_sys)
++        install_sys_qpa();
+ }
+ 
+ void QSystemTrayIconPrivate::remove_sys()
+ {
+     if (qpa_sys)
+-        qpa_sys->cleanup();
++        remove_sys_qpa();
+ }
+ 
+ QRect QSystemTrayIconPrivate::geometry_sys() const
+ {
+     if (qpa_sys)
+-        return qpa_sys->geometry();
++        return geometry_sys_qpa();
+     else
+         return QRect();
+ }
+@@ -94,25 +86,19 @@ QRect QSystemTrayIconPrivate::geometry_sys() const
+ void QSystemTrayIconPrivate::updateIcon_sys()
+ {
+     if (qpa_sys)
+-        qpa_sys->updateIcon(icon);
++        updateIcon_sys_qpa();
+ }
+ 
+ void QSystemTrayIconPrivate::updateMenu_sys()
+ {
+-    if (qpa_sys && menu) {
+-        if (!menu->platformMenu()) {
+-            QPlatformMenu *platformMenu = qpa_sys->createMenu();
+-            if (platformMenu)
+-                menu->setPlatformMenu(platformMenu);
+-        }
+-        qpa_sys->updateMenu(menu->platformMenu());
+-    }
++    if (qpa_sys)
++        updateMenu_sys_qpa();
+ }
+ 
+ void QSystemTrayIconPrivate::updateToolTip_sys()
+ {
+     if (qpa_sys)
+-        qpa_sys->updateToolTip(toolTip);
++        updateToolTip_sys_qpa();
+ }
+ 
+ bool QSystemTrayIconPrivate::isSystemTrayAvailable_sys()
+@@ -138,25 +124,8 @@ void QSystemTrayIconPrivate::showMessage_sys(const QString &message,
+                                              QSystemTrayIcon::MessageIcon icon,
+                                              int msecs)
+ {
+-    if (!qpa_sys)
+-        return;
+-
+-    QIcon notificationIcon;
+-    switch (icon) {
+-    case QSystemTrayIcon::Information:
+-        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation);
+-        break;
+-    case QSystemTrayIcon::Warning:
+-        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
+-        break;
+-    case QSystemTrayIcon::Critical:
+-        notificationIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical);
+-        break;
+-    default:
+-        break;
+-    }
+-    qpa_sys->showMessage(message, title, notificationIcon,
+-                     static_cast<QPlatformSystemTrayIcon::MessageIcon>(icon), msecs);
++    if (qpa_sys)
++        showMessage_sys_qpa(message, title, icon, msecs);
+ }
+ 
+ QT_END_NAMESPACE
+diff --git a/src/widgets/util/qsystemtrayicon_x11.cpp b/src/widgets/util/qsystemtrayicon_x11.cpp
+index 347e570..27d0418 100644
+--- a/src/widgets/util/qsystemtrayicon_x11.cpp
++++ b/src/widgets/util/qsystemtrayicon_x11.cpp
+@@ -55,6 +55,9 @@
+ #include <qscreen.h>
+ #include <qbackingstore.h>
+ #include <qpa/qplatformnativeinterface.h>
++#include <qpa/qplatformsystemtrayicon.h>
++#include <qpa/qplatformtheme.h>
++#include <private/qguiapplication_p.h>
+ #include <qdebug.h>
+ 
+ #ifndef QT_NO_SYSTEMTRAYICON
+@@ -209,16 +212,22 @@ void QSystemTrayIconSys::paintEvent(QPaintEvent *)
+ 
+ QSystemTrayIconPrivate::QSystemTrayIconPrivate()
+     : sys(0),
++      qpa_sys(QGuiApplicationPrivate::platformTheme()->createPlatformSystemTrayIcon()),
+       visible(false)
+ {
+ }
+ 
+ QSystemTrayIconPrivate::~QSystemTrayIconPrivate()
+ {
++    delete qpa_sys;
+ }
+ 
+ void QSystemTrayIconPrivate::install_sys()
+ {
++    if (qpa_sys) {
++        install_sys_qpa();
++        return;
++    }
+     Q_Q(QSystemTrayIcon);
+     if (!sys && locateSystemTray()) {
+         sys = new QSystemTrayIconSys(q);
+@@ -229,6 +238,8 @@ void QSystemTrayIconPrivate::install_sys()
+ 
+ QRect QSystemTrayIconPrivate::geometry_sys() const
+ {
++    if (qpa_sys)
++        return geometry_sys_qpa();
+     if (!sys)
+         return QRect();
+     return sys->globalGeometry();
+@@ -236,6 +247,10 @@ QRect QSystemTrayIconPrivate::geometry_sys() const
+ 
+ void QSystemTrayIconPrivate::remove_sys()
+ {
++    if (qpa_sys) {
++        remove_sys_qpa();
++        return;
++    }
+     if (!sys)
+         return;
+     QBalloonTip::hideBalloon();
+@@ -246,17 +261,26 @@ void QSystemTrayIconPrivate::remove_sys()
+ 
+ void QSystemTrayIconPrivate::updateIcon_sys()
+ {
++    if (qpa_sys) {
++        updateIcon_sys_qpa();
++        return;
++    }
+     if (sys)
+         sys->updateIcon();
+ }
+ 
+ void QSystemTrayIconPrivate::updateMenu_sys()
+ {
+-
++    if (qpa_sys)
++        updateMenu_sys_qpa();
+ }
+ 
+ void QSystemTrayIconPrivate::updateToolTip_sys()
+ {
++    if (qpa_sys) {
++        updateToolTip_sys_qpa();
++        return;
++    }
+     if (!sys)
+         return;
+ #ifndef QT_NO_TOOLTIP
+@@ -266,6 +290,11 @@ void QSystemTrayIconPrivate::updateToolTip_sys()
+ 
+ bool QSystemTrayIconPrivate::isSystemTrayAvailable_sys()
+ {
++    QScopedPointer<QPlatformSystemTrayIcon> sys(QGuiApplicationPrivate::platformTheme()->createPlatformSystemTrayIcon());
++    if (sys)
++        return sys->isSystemTrayAvailable();
++
++    // no QPlatformSystemTrayIcon so fall back to default xcb platform behavior
+     const QString platform = QGuiApplication::platformName();
+     if (platform.compare(QStringLiteral("xcb"), Qt::CaseInsensitive) == 0)
+        return locateSystemTray();
+@@ -274,12 +303,21 @@ bool QSystemTrayIconPrivate::isSystemTrayAvailable_sys()
+ 
+ bool QSystemTrayIconPrivate::supportsMessages_sys()
+ {
++    QScopedPointer<QPlatformSystemTrayIcon> sys(QGuiApplicationPrivate::platformTheme()->createPlatformSystemTrayIcon());
++    if (sys)
++        return sys->supportsMessages();
++
++    // no QPlatformSystemTrayIcon so fall back to default xcb platform behavior
+     return true;
+ }
+ 
+ void QSystemTrayIconPrivate::showMessage_sys(const QString &message, const QString &title,
+                                    QSystemTrayIcon::MessageIcon icon, int msecs)
+ {
++    if (qpa_sys) {
++        showMessage_sys_qpa(message, title, icon, msecs);
++        return;
++    }
+     if (!sys)
+         return;
+     const QPoint g = sys->globalGeometry().topLeft();
+-- 
+1.7.1
+

--- a/dev-qt/qtwidgets/qtwidgets-5.3.1-r1.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.3.1-r1.ebuild
@@ -24,6 +24,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}/${PN}-5.3.1-prefer-qpa.patch" )
+
 QT5_TARGET_SUBDIRS=(
 	src/tools/uic
 	src/widgets


### PR DESCRIPTION
Recomended by KDE developers, for more informations look at
http://blog.martin-graesslin.com/blog/2014/06/where-are-my-systray-icons/

Signed-off-by: David Heidelberger david.heidelberger@ixit.cz
