### PR TITLE
[app-crypt/qca] Install the QCA plugins into the Qt plugin directory.

### DIFF
--- a/app-crypt/qca/qca-9999.ebuild
+++ b/app-crypt/qca/qca-9999.ebuild
@@ -68,6 +68,11 @@ src_configure() {
 		$(with_plugin_use pkcs11)
 		$(with_plugin_use softstore)
 	)
+	if use qt4; then
+		mycmakeargs+=(-DQCA_PLUGINS_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)/qt4/plugins/crypto")
+	else
+		mycmakeargs+=(-DQCA_PLUGINS_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)/qt5/plugins/crypto")
+	fi
 
 	cmake-utils_src_configure
 }


### PR DESCRIPTION
Fixes the install location for QCA's plugins.
Otherwise `app-crypt/qca-9999` is pretty much non-functional, as it doesn't find any of its plugins.

For anyone who wasn't able to get `kde-misc/kdeconnect-9999` working - it works here now after this fix.
