### PR TITLE
[app-crypt/qca] Correct plugin path to upstream changes

### DIFF
--- a/app-crypt/qca/qca-9999.ebuild
+++ b/app-crypt/qca/qca-9999.ebuild
@@ -56,7 +56,7 @@ qca_plugin_use() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DQCA_PLUGINS_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)/$(usex qt4 qt4 qt5)/plugins/crypto"
+		-DQCA_PLUGINS_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)/$(usex qt4 qt4 qt5)/plugins"
 		-DQCA_FEATURE_INSTALL_DIR="${EPREFIX}/usr/$(usex qt4 share $(get_libdir))/$(usex qt4 qt4 qt5)/mkspecs/features"
 		$(cmake-utils_use qt4 QT4_BUILD)
 		$(qca_plugin_use botan)


### PR DESCRIPTION
See: http://quickgit.kde.org/?p=qca.git&a=commitdiff&h=192243d4bdafddf38dd7a7b508524ee5cb1ecdb5&hp=2950458c77928bf0f096e61f5a069bdb2862665e

Package-Manager: portage-2.2.12
