### PR TITLE
[dev-qt/qtwebkit] Rework HTML5 A/V backend

### DIFF
--- a/dev-qt/qtwebkit/files/qtwebkit-5.3.2-use-gstreamer010.patch
+++ b/dev-qt/qtwebkit/files/qtwebkit-5.3.2-use-gstreamer010.patch
@@ -1,0 +1,18 @@
+--- Tools/qmake/mkspecs/features/features.prf	2014-09-27 11:09:50.010617142 +0100
++++ Tools/qmake/mkspecs/features/features.prf	2014-09-27 11:17:10.741678989 +0100
+@@ -96,14 +96,8 @@
+     use?(3d_graphics): WEBKIT_CONFIG += webgl
+ 
+     # HTML5 Media Support for builds with GStreamer
+-    unix:!mac:!contains(QT_CONFIG, no-pkg-config) {
+-        packagesExist("glib-2.0 gio-2.0 gstreamer-1.0 gstreamer-plugins-base-1.0") {
+-            WEBKIT_CONFIG += video use_gstreamer
+-        } else: packagesExist("glib-2.0 gio-2.0 \'gstreamer-0.10 >= 0.10.30\' \'gstreamer-plugins-base-0.10 >= 0.10.30\'") {
+-            WEBKIT_CONFIG += video use_gstreamer use_gstreamer010
+-        }
++        WEBKIT_CONFIG += video use_gstreamer use_gstreamer010
+         use?(gstreamer): WEBKIT_CONFIG += use_native_fullscreen_video
+-    }
+ 
+     !enable?(video):qtHaveModule(multimediawidgets) {
+         WEBKIT_CONFIG += video use_qt_multimedia

--- a/dev-qt/qtwebkit/metadata.xml
+++ b/dev-qt/qtwebkit/metadata.xml
@@ -5,7 +5,8 @@
 	<use>
 		<flag name="exceptions">Add support for exceptions - like catching them
 			inside the event loop (recommended by Nokia)</flag>
-		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer</pkg></flag>
+		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer:1.0</pkg></flag>
+		<flag name="gstreamer010">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer:0.10</pkg></flag>
 		<flag name="libxml2">Use <pkg>dev-libs/libxml2</pkg> for XML parsing</flag>
 		<flag name="multimedia">Enable HTML5 audio/video support via <pkg>dev-qt/qtmultimedia</pkg></flag>
 		<flag name="printsupport">Enable printing via <pkg>dev-qt/qtprintsupport</pkg></flag>

--- a/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.3.9999.ebuild
@@ -18,7 +18,8 @@ fi
 
 # TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp xslt"
+IUSE="gstreamer gstreamer010 libxml2 multimedia opengl printsupport qml udev webp xslt"
+REQUIRED_USE="?? ( gstreamer gstreamer010 multimedia )"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -38,11 +39,16 @@ RDEPEND="
 	x11-libs/libXrender
 	gstreamer? (
 		dev-libs/glib:2
-		>=media-libs/gstreamer-0.10.30:0.10
-		>=media-libs/gst-plugins-base-0.10.30:0.10
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-base:0.10
 	)
 	libxml2? ( dev-libs/libxml2:2 )
-	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
+	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=,widgets] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
 	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
@@ -61,7 +67,11 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	if use gstreamer010; then
+		epatch "${FILESDIR}/${PN}-5.3.2-use-gstreamer010.patch"
+	elif ! use gstreamer; then
+		epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	fi
 	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \

--- a/dev-qt/qtwebkit/qtwebkit-5.4.0_alpha.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.4.0_alpha.ebuild
@@ -18,7 +18,8 @@ fi
 
 # TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp xslt"
+IUSE="gstreamer gstreamer010 libxml2 multimedia opengl printsupport qml udev webp xslt"
+REQUIRED_USE="?? ( gstreamer gstreamer010 multimedia )"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -38,11 +39,16 @@ RDEPEND="
 	x11-libs/libXrender
 	gstreamer? (
 		dev-libs/glib:2
-		>=media-libs/gstreamer-0.10.30:0.10
-		>=media-libs/gst-plugins-base-0.10.30:0.10
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-base:0.10
 	)
 	libxml2? ( dev-libs/libxml2:2 )
-	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
+	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=,widgets] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
 	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
@@ -61,7 +67,11 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	if use gstreamer010; then
+		epatch "${FILESDIR}/${PN}-5.3.2-use-gstreamer010.patch"
+	elif ! use gstreamer; then
+		epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	fi
 	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \

--- a/dev-qt/qtwebkit/qtwebkit-5.4.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.4.9999.ebuild
@@ -18,7 +18,8 @@ fi
 
 # TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp xslt"
+IUSE="gstreamer gstreamer010 libxml2 multimedia opengl printsupport qml udev webp xslt"
+REQUIRED_USE="?? ( gstreamer gstreamer010 multimedia )"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -38,11 +39,16 @@ RDEPEND="
 	x11-libs/libXrender
 	gstreamer? (
 		dev-libs/glib:2
-		>=media-libs/gstreamer-0.10.30:0.10
-		>=media-libs/gst-plugins-base-0.10.30:0.10
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-base:0.10
 	)
 	libxml2? ( dev-libs/libxml2:2 )
-	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
+	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=,widgets] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
 	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
@@ -61,7 +67,11 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	if use gstreamer010; then
+		epatch "${FILESDIR}/${PN}-5.3.2-use-gstreamer010.patch"
+	elif ! use gstreamer; then
+		epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	fi
 	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \

--- a/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
@@ -18,7 +18,8 @@ fi
 
 # TODO: qttestlib, geolocation, orientation/sensors
 
-IUSE="gstreamer libxml2 multimedia opengl printsupport qml udev webp xslt"
+IUSE="gstreamer gstreamer010 libxml2 multimedia opengl printsupport qml udev webp xslt"
+REQUIRED_USE="?? ( gstreamer gstreamer010 multimedia )"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -38,11 +39,16 @@ RDEPEND="
 	x11-libs/libXrender
 	gstreamer? (
 		dev-libs/glib:2
-		>=media-libs/gstreamer-0.10.30:0.10
-		>=media-libs/gst-plugins-base-0.10.30:0.10
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-base:0.10
 	)
 	libxml2? ( dev-libs/libxml2:2 )
-	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=] )
+	multimedia? ( >=dev-qt/qtmultimedia-${PV}:5[debug=,widgets] )
 	opengl? ( >=dev-qt/qtopengl-${PV}:5[debug=] )
 	printsupport? ( >=dev-qt/qtprintsupport-${PV}:5[debug=] )
 	qml? ( >=dev-qt/qtdeclarative-${PV}:5[debug=] )
@@ -61,7 +67,11 @@ DEPEND="${RDEPEND}
 "
 
 src_prepare() {
-	use gstreamer    || epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	if use gstreamer010; then
+		epatch "${FILESDIR}/${PN}-5.3.2-use-gstreamer010.patch"
+	elif ! use gstreamer; then
+		epatch "${FILESDIR}/${PN}-5.2.1-disable-gstreamer.patch"
+	fi
 	use libxml2      || sed -i -e '/config_libxml2: WEBKIT_CONFIG += use_libxml2/d' \
 		Tools/qmake/mkspecs/features/features.prf || die
 	use multimedia   || sed -i -e '/WEBKIT_CONFIG += video use_qt_multimedia/d' \


### PR DESCRIPTION
- Fixes bug #523518
- Instead of simply depending on gstreamer, add a separate USE for
  gstreamer:0.10 to clearly specify which slot should be linked to.

See https://bugs.gentoo.org/show_bug.cgi?id=523518
