### PR TITLE
[dev-qt/qtcore] Add journald logging support (qtbase f81de394)

### DIFF
--- a/dev-qt/qtcore/metadata.xml
+++ b/dev-qt/qtcore/metadata.xml
@@ -8,6 +8,7 @@
 		<flag name="glib">Enable <pkg>dev-libs/glib</pkg> eventloop support</flag>
 		<flag name="qt3support">Enable the Qt3Support libraries for Qt4. Note that
 			this does not mean you can compile pure Qt3 programs with Qt4.</flag>
+		<flag name="systemd">Enable native journald logging support</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt-project.org/</bugs-to>

--- a/dev-qt/qtcore/qtcore-5.4.0_rc.ebuild
+++ b/dev-qt/qtcore/qtcore-5.4.0_rc.ebuild
@@ -16,7 +16,7 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-IUSE="icu"
+IUSE="icu systemd"
 
 DEPEND="
 	dev-libs/glib:2
@@ -24,6 +24,7 @@ DEPEND="
 	sys-libs/zlib
 	virtual/libiconv
 	icu? ( dev-libs/icu:= )
+	systemd? ( sys-apps/systemd )
 "
 RDEPEND="${DEPEND}"
 
@@ -38,6 +39,7 @@ QT5_TARGET_SUBDIRS=(
 src_configure() {
 	local myconf=(
 		$(qt_use icu)
+		$(qt_use systemd journald)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtcore/qtcore-5.4.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.4.9999.ebuild
@@ -16,7 +16,7 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-IUSE="icu"
+IUSE="icu systemd"
 
 DEPEND="
 	dev-libs/glib:2
@@ -24,6 +24,7 @@ DEPEND="
 	sys-libs/zlib
 	virtual/libiconv
 	icu? ( dev-libs/icu:= )
+	systemd? ( sys-apps/systemd )
 "
 RDEPEND="${DEPEND}"
 
@@ -38,6 +39,7 @@ QT5_TARGET_SUBDIRS=(
 src_configure() {
 	local myconf=(
 		$(qt_use icu)
+		$(qt_use systemd journald)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -16,7 +16,7 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-IUSE="icu"
+IUSE="icu systemd"
 
 DEPEND="
 	dev-libs/glib:2
@@ -24,6 +24,7 @@ DEPEND="
 	sys-libs/zlib
 	virtual/libiconv
 	icu? ( dev-libs/icu:= )
+	systemd? ( sys-apps/systemd )
 "
 RDEPEND="${DEPEND}"
 
@@ -38,6 +39,7 @@ QT5_TARGET_SUBDIRS=(
 src_configure() {
 	local myconf=(
 		$(qt_use icu)
+		$(qt_use systemd journald)
 	)
 	qt5-build_src_configure
 }


### PR DESCRIPTION
Package-Manager: portage-2.2.14

In qtproject/qtbase@f81de394 support for using journald as logging facility was added.
- This will only affect non-interactive applications.
- It can be overridden on demand using `QT_NO_JOURNALD_LOG=1` as environment variable
