### PR TITLE
Remove switch for Qt5

### DIFF
--- a/lxqt-base/liblxqt/liblxqt-9999.ebuild
+++ b/lxqt-base/liblxqt/liblxqt-9999.ebuild
@@ -42,10 +42,3 @@ pkg_pretend() {
 			die 'The active compiler needs to be gcc 4.8 (or newer)'
 	fi
 }
-
-src_configure() {
-	local mycmakeargs=(
-		-DUSE_QT5=ON
-	)
-	cmake-utils_src_configure
-}


### PR DESCRIPTION
Lxqt dropped Qt4 support, thus this is not needed anymore.
See commit b11ac14c5efa430e028f847cf3eefc8b8c5d150e and
2bf3372b424b4d371b944928f7a3800d0c22a692 in liblxqt repo for proof of
that.

Version 0.8 still has it, from then on they will change it.
