### PR TITLE
[lxqt-base] LXQt SRC_URI change

### DIFF
--- a/lxqt-base/liblxqt-mount/liblxqt-mount-9999.ebuild
+++ b/lxqt-base/liblxqt-mount/liblxqt-mount-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/liblxqt/liblxqt-9999.ebuild
+++ b/lxqt-base/liblxqt/liblxqt-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/libsysstat/libsysstat-9999.ebuild
+++ b/lxqt-base/libsysstat/libsysstat-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PN}/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-about/lxqt-about-9999.ebuild
+++ b/lxqt-base/lxqt-about/lxqt-about-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-common/lxqt-common-9999.ebuild
+++ b/lxqt-base/lxqt-common/lxqt-common-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/lxqt/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-config-randr/lxqt-config-randr-9999.ebuild
+++ b/lxqt-base/lxqt-config-randr/lxqt-config-randr-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 	S=${WORKDIR}
 fi

--- a/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
+++ b/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-globalkeys/lxqt-globalkeys-9999.ebuild
+++ b/lxqt-base/lxqt-globalkeys/lxqt-globalkeys-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-notificationd/lxqt-notificationd-9999.ebuild
+++ b/lxqt-base/lxqt-notificationd/lxqt-notificationd-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-panel/lxqt-panel-9999.ebuild
+++ b/lxqt-base/lxqt-panel/lxqt-panel-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/lxqt/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-policykit/lxqt-policykit-9999.ebuild
+++ b/lxqt-base/lxqt-policykit/lxqt-policykit-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-9999.ebuild
+++ b/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/lxqt/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-9999.ebuild
+++ b/lxqt-base/lxqt-qtplugin/lxqt-qtplugin-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-runner/lxqt-runner-9999.ebuild
+++ b/lxqt-base/lxqt-runner/lxqt-runner-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/lxqt-base/lxqt-session/lxqt-session-9999.ebuild
+++ b/lxqt-base/lxqt-session/lxqt-session-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="git://git.lxde.org/git/lxde/${PN}.git"
 else
-	SRC_URI="http://lxqt.org/downloads/${PV}/${P}.tar.xz"
+	SRC_URI="http://downloads.lxqt.org/lxqt/${PV}/${P}.tar.xz"
 	KEYWORDS="~amd64 ~x86"
 fi
 


### PR DESCRIPTION
On 18.01.2015 J. Leclanche announced on the LXDE mailing list that the
package download path will change in a few weeks (with the release of
0.9.0). The change of download paths affacts all version.

The new locations are already working, so here is the change that needs
to be done.