### PR TITLE
[dev-qt/qtwebkit23] add support for building with libxml2[icu]

### DIFF
--- a/dev-qt/qtwebkit23/files/qtwebkit23-2.3.4-use-correct-typedef.patch
+++ b/dev-qt/qtwebkit23/files/qtwebkit23-2.3.4-use-correct-typedef.patch
@@ -1,0 +1,40 @@
+From 916f00008b602ae1b260106e7fb1274d2282f61f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Kundr=C3=A1t?= <jkt@flaska.net>
+Date: Tue, 3 Sep 2013 16:59:35 +0200
+Subject: [PATCH] ICU has defined UChar32 to be an int32_t since 2002
+
+This fixes the build failure of qtwebkit23 on my Gentoo machine.
+---
+ Source/WTF/wtf/unicode/qt4/UnicodeQt4.h     |    2 +-
+ Source/WTF/wtf/unicode/wchar/UnicodeWchar.h |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WTF/wtf/unicode/qt4/UnicodeQt4.h b/Source/WTF/wtf/unicode/qt4/UnicodeQt4.h
+index a2d1ad4..392d2db 100644
+--- a/Source/WTF/wtf/unicode/qt4/UnicodeQt4.h
++++ b/Source/WTF/wtf/unicode/qt4/UnicodeQt4.h
+@@ -69,7 +69,7 @@ typedef uint16_t UChar;
+ #endif
+ 
+ #if !USE(ICU_UNICODE)
+-typedef uint32_t UChar32;
++typedef int32_t UChar32;
+ #endif
+ 
+ namespace WTF {
+diff --git a/Source/WTF/wtf/unicode/wchar/UnicodeWchar.h b/Source/WTF/wtf/unicode/wchar/UnicodeWchar.h
+index 10c2026..db8944e 100644
+--- a/Source/WTF/wtf/unicode/wchar/UnicodeWchar.h
++++ b/Source/WTF/wtf/unicode/wchar/UnicodeWchar.h
+@@ -31,7 +31,7 @@
+ #include <wtf/unicode/UnicodeMacrosFromICU.h>
+ 
+ typedef wchar_t UChar;
+-typedef uint32_t UChar32;
++typedef int32_t UChar32;
+ 
+ namespace WTF {
+ namespace Unicode {
+-- 
+1.7.1
+

--- a/dev-qt/qtwebkit23/qtwebkit23-2.3.4.ebuild
+++ b/dev-qt/qtwebkit23/qtwebkit23-2.3.4.ebuild
@@ -16,11 +16,9 @@ SLOT="4"
 KEYWORDS="~amd64"
 
 IUSE="+gstreamer"
-# libxml2[!icu] is needed for bugs 407315 and 411091
-# https://bugs.webkit.org/show_bug.cgi?id=82824
 RDEPEND="
 	>=dev-db/sqlite-3.8.3:3
-	dev-libs/libxml2:2[-icu]
+	dev-libs/libxml2:2
 	dev-libs/libxslt
 	dev-qt/qtcore:4[ssl]
 	dev-qt/qtdeclarative:4
@@ -62,6 +60,8 @@ src_prepare() {
 	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
 
 	sed -i -e "/QMAKE_CXXFLAGS_RELEASE/d" Source/WTF/WTF.pro Source/JavaScriptCore/Target.pri || die
+
+	epatch "${FILESDIR}"/${PN}-2.3.4-use-correct-typedef.patch
 }
 
 src_compile() {


### PR DESCRIPTION
Add a patch to let it build when libxml2 is compiled with icu support
enabled. This solves conflicts with, e.g., chromium depending on
libxml2[icu]

I tested this ebuild to see if it is solving bug #522880 (when phonon-gstreamer-4.8.x is used there is a gstreamer 0.10, loaded by qtwebkit, vs 1.x, loaded by phonon, symbol collision in applications needing both gstreamer and qtwebkit, like amarok). The issue is solved as expected and phonon-gstreamer 4.8 works as expected. See also comment #35 in bug #522880

Note this ebuild currently generates a file collision with dev-qt/qtdeclarative-4.8.x
```
 * Detected file collision(s):
 *
 *      /usr/lib64/qt4/imports/QtWebKit/libqmlwebkitplugin.so
 *      /usr/lib64/qt4/imports/QtWebKit/qmldir
 *
 * Searching all installed packages for file collisions...
 *
 * Press Ctrl-C to Stop
 *
 * dev-qt/qtdeclarative-4.8.5:4::gentoo
 *      /usr/lib64/qt4/imports/QtWebKit/libqmlwebkitplugin.so
 *      /usr/lib64/qt4/imports/QtWebKit/qmldir
```
So i forcefully disabled webkit support in qtdeclarative by passing -no-webkit and dropped the DEP. Packages depending on qtdeclarative[webkit], like kdevelop, will need a little adjustment. With this change qtwebkit 2.3.4 can be installed, I fired up rekonq briefly and it worked as expected (tried to load youtube in html5).