### PR TITLE
Make it possible to configure debug builds on a per-package basis

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -658,6 +658,7 @@ qt5_qmake() {
 		QMAKE_LFLAGS="${LDFLAGS}" \
 		QMAKE_LFLAGS_RELEASE= \
 		QMAKE_LFLAGS_DEBUG= \
+		$(use debug && echo "CONFIG+=debug" || echo "CONFIG-=debug") \
 		"${projectdir}" \
 		"$@" \
 		|| die "qmake failed (${projectdir})"


### PR DESCRIPTION
Previous version of this code only did something useful for qtbase, and
relied on qmake to propagate this change to other Qt modules. Because Qt
modules can be easily built with different debug settings, let's make it
work.

Tested with USE=-debug on everything and USE=debug on
qtdeclarative-5.5.9999.