### PR TITLE
Minitube

### DIFF
--- a/media-video/minitube/minitube-9999.ebuild
+++ b/media-video/minitube/minitube-9999.ebuild
@@ -36,6 +36,22 @@ S=${WORKDIR}/${PN}
 
 DOCS="AUTHORS CHANGES TODO"
 
+pkg_pretend() {
+	if [[ -z ${MINITUBE_GOOGLE_API_KEY} ]]; then
+		eerror ""
+		eerror "Since version 2.4, you need to generate a Google API Key to use"
+		eerror "with this application. Please head over to"
+		eerror "https://console.developers.google.com/ and"
+		eerror "https://github.com/flaviotordini/minitube/blob/master/README.md"
+		eerror "for more information. Once you have generated your key,"
+		eerror "please export it to your environment ie :"
+		eerror "'export MINITUBE_GOOGLE_API_KEY=\"YourAPIKeyHere\""
+		eerror "and then try to merge this package again"
+		eerror ""
+		die "MINITUBE_GOOGLE_API_KEY env variable not defined!"
+	fi
+}
+
 src_prepare() {
 	qt4-r2_src_prepare
 
@@ -51,6 +67,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.9-gcc47.patch
 	# Enable video downloads. Bug #491344
 	use download && { echo "DEFINES += APP_DOWNLOADS" >> ${PN}.pro; }
+	echo "DEFINES += APP_GOOGLE_API_KEY=${MINITUBE_GOOGLE_API_KEY}" >> ${PN}.pro
 }
 
 src_install() {

--- a/media-video/minitube/minitube-9999.ebuild
+++ b/media-video/minitube/minitube-9999.ebuild
@@ -7,7 +7,7 @@ PLOCALES="ar ca ca_ES da de_DE el en es es_AR es_ES fi fi_FI fr gl he_IL hr hu
 ia id it jv ka_GE nb nl nn pl pl_PL pt pt_BR ro ru sk sl sq sr sv_SE tr uk_UA
 zh_CN"
 
-EGIT_REPO_URI="git://gitorious.org/minitube/minitube.git"
+EGIT_REPO_URI="https://github.com/flaviotordini/minitube.git"
 inherit l10n qt4-r2 git-2
 
 DESCRIPTION="Qt4 YouTube Client"


### PR DESCRIPTION
Fix SRC_URI, add MINITUBE_GOOGLE_API_KEY from portage downstream.

Also, if you're testing these compile-time keys, pay special attention to this... http://flavio.tordini.org/forums/topic/error-downloading-server-reply-forbidden#post-93714

Google is doing a real number on their APIs right now, but this seems to work.