### PR TITLE
[app-admin/keepassx] Remove QtTest if test not set

### DIFF
--- a/app-admin/keepassx/keepassx-9999.ebuild
+++ b/app-admin/keepassx/keepassx-9999.ebuild
@@ -27,6 +27,11 @@ DEPEND="${RDEPEND}
 	test? ( dev-qt/qttest:4 )
 "
 
+src_prepare() {
+	 use test || \
+		 sed -e "/^set(QT_REQUIRED_MODULES/s/QtTest//" -i CMakeLists.txt || die
+}
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake-utils_use_with test TESTS)


### PR DESCRIPTION
Building app-admin/keepassx-9999 currently fails bcause dev-qt/qttest:4 isn't pulled in as a dependency.

Error message (versions mentioned in error message seems to refer to some other qt package. Perhaps dev-qt/qtcore).
``````
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find Qt4 (missing: QT_QTTEST_INCLUDE_DIR QT_QTTEST_LIBRARY)
  (found suitable version "4.8.6", minimum required is "4.6.0")
``````