### PR TITLE
add dependency on kde-frameworks/solid

### DIFF
--- a/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-9999.ebuild
+++ b/lxqt-base/lxqt-powermanagement/lxqt-powermanagement-9999.ebuild
@@ -28,6 +28,7 @@ CDEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
+	kde-frameworks/solid:5
 	~lxqt-base/liblxqt-${PV}
 	>=dev-libs/libqtxdg-1.0.0
 	x11-libs/libX11


### PR DESCRIPTION
lxqt-base/lxqt-powermanagement seems to have a dependency missing…

```
CMake Error at CMakeLists.txt:18 (find_package):
  By not providing "FindKF5Solid.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "KF5Solid",
  but CMake did not find one.

  Could not find a package configuration file provided by "KF5Solid" with any
  of the following names:

    KF5SolidConfig.cmake
    kf5solid-config.cmake

  Add the installation prefix of "KF5Solid" to CMAKE_PREFIX_PATH or set
  "KF5Solid_DIR" to a directory containing one of the above files.  If
  "KF5Solid" provides a separate development package or SDK, be sure it has
  been installed.

-- Configuring incomplete, errors occurred!
```

Works after emerging `solid`.