### PR TITLE
lxqt-panel – add dependency on libdbusmenu-qt

### DIFF
--- a/lxqt-base/lxqt-panel/lxqt-panel-9999.ebuild
+++ b/lxqt-base/lxqt-panel/lxqt-panel-9999.ebuild
@@ -43,6 +43,7 @@ DEPEND="
 	x11-libs/libXcomposite
 	x11-libs/libXdamage
 	x11-libs/libXrender
+	dev-libs/libdbusmenu-qt[qt5]
 	cpuload? ( sys-libs/libstatgrab )
 	networkmonitor? ( sys-libs/libstatgrab )
 	sensors? ( sys-apps/lm_sensors )


### PR DESCRIPTION
lxqt-base/lxqt-panel seems to have a dependency missing…

```
-- checking for module 'dbusmenu-qt5'
--   package 'dbusmenu-qt5' not found
CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:340 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:502 (_pkg_check_modules_internal)
  plugin-statusnotifier/CMakeLists.txt:6 (pkg_check_modules)

-- Configuring incomplete, errors occurred!
```