### PR TITLE
change libqtxdg dependency  to live version

### DIFF
--- a/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
+++ b/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
@@ -20,7 +20,7 @@ LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0"
 
 DEPEND="
-	>=dev-libs/libqtxdg-1.0.0
+	=dev-libs/libqtxdg-${PV}
 	dev-qt/linguist-tools:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5

--- a/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
+++ b/lxqt-base/lxqt-config/lxqt-config-9999.ebuild
@@ -20,7 +20,7 @@ LICENSE="GPL-2 LGPL-2.1+"
 SLOT="0"
 
 DEPEND="
-	=dev-libs/libqtxdg-${PV}
+	~dev-libs/libqtxdg-${PV}
 	dev-qt/linguist-tools:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5


### PR DESCRIPTION
lxqt-config-9999 does not merge with dev-libs/libqtxdg-1.1.0:

```
/var/tmp/portage/lxqt-base/lxqt-config-9999/work/lxqt-config-9999/lxqt-config-appearance/iconthemeconfig.cpp:38:41: fatal error: private/qtxdg
/qiconloader_p.h: No such file or directory
 #include <private/qtxdg/qiconloader_p.h>
                                         ^
compilation terminated.
lxqt-config-appearance/CMakeFiles/lxqt-config-appearance.dir/build.make:303: recipe for target 'lxqt-config-appearance/CMakeFiles/lxqt-config-
appearance.dir/iconthemeconfig.cpp.o' failed
make[2]: *** [lxqt-config-appearance/CMakeFiles/lxqt-config-appearance.dir/iconthemeconfig.cpp.o] Error 1
make[2]: Leaving directory '/var/tmp/portage/lxqt-base/lxqt-config-9999/work/lxqt-config-9999_build'
CMakeFiles/Makefile2:491: recipe for target 'lxqt-config-appearance/CMakeFiles/lxqt-config-appearance.dir/all' failed
make[1]: *** [lxqt-config-appearance/CMakeFiles/lxqt-config-appearance.dir/all] Error 2
```
…

```
make: *** [all] Error 2
 * ERROR: lxqt-base/lxqt-config-9999::qt failed (compile phase):
 *   emake failed
```

Works with libqtxdg-9999.