### PR TITLE
[dev-qt/qtwebkit23] Move pkgconfig file

### DIFF
--- a/dev-qt/qtwebkit23/qtwebkit23-2.3.4.ebuild
+++ b/dev-qt/qtwebkit23/qtwebkit23-2.3.4.ebuild
@@ -109,4 +109,5 @@ multilib_src_compile() {
 
 multilib_src_install() {
 	emake INSTALL_ROOT="${D}" install -C $(usex debug Debug Release)
+	mv "${D}"/usr/$(get_libdir)/qt4/pkgconfig "${D}"/usr/$(get_libdir)/pkgconfig || die
 }


### PR DESCRIPTION
Move from /usr/lib{64,}/qt4/pkgconfig to /usr/lib{64,}/pkgconfig

To me it is a bit odd how this is "computed". If I understood correctly the code involved is from Source/api.pri

```
    !isEmpty(INSTALL_LIBS): target.path = $$INSTALL_LIBS
    else: target.path = $$[QT_INSTALL_LIBS]
    INSTALLS += target

    unix {
        CONFIG += create_pc create_prl
        QMAKE_PKGCONFIG_LIBDIR = $$target.path
        QMAKE_PKGCONFIG_INCDIR = $$headers.path
        QMAKE_PKGCONFIG_DESTDIR = pkgconfig
        lib_replace.match = $$re_escape($$DESTDIR)
        lib_replace.replace = $$[QT_INSTALL_LIBS]
        QMAKE_PKGCONFIG_INSTALL_REPLACE += lib_replace
    }
```

So the pkconfig dir is relative, but it is not really clear to me to what is relative. Looking at Fedora spec file the only difference I can spot is that they set QMAKEPATH and use a wrapper for qmake, places in a $BUILD_DIR/bin and put before everything in $PATH.

Is the change in the commit good enough or should investigate more?