### PR TITLE
dev-qt/qtmultimedia-5.5.0 Enabling gstreamer1.0 and let gstreamer0.10…

### DIFF
--- a/dev-qt/qtmultimedia/metadata.xml
+++ b/dev-qt/qtmultimedia/metadata.xml
@@ -7,6 +7,8 @@
 			inside the event loop (recommended by upstream)</flag>
 		<flag name="qml">Build QML/QtQuick bindings and imports</flag>
 		<flag name="widgets">Build the QtMultimediaWidgets module</flag>
+		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer:1.0</pkg></flag>
+		<flag name="gstreamer010">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer:0.10</pkg></flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtmultimedia/qtmultimedia-5.5.0.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.5.0.ebuild
@@ -11,7 +11,8 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
 fi
 
-IUSE="alsa +gstreamer openal opengl pulseaudio qml widgets"
+IUSE="alsa gstreamer gstreamer010 openal opengl pulseaudio qml widgets"
+REQUIRED_USE="?? ( gstreamer gstreamer010 )"
 
 RDEPEND="
 	>=dev-qt/qtcore-${PV}:5
@@ -19,6 +20,11 @@ RDEPEND="
 	>=dev-qt/qtnetwork-${PV}:5
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
+		media-libs/gstreamer:1.0
+        media-libs/gst-plugins-bad:1.0
+        media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
 		media-libs/gstreamer:0.10
 		media-libs/gst-plugins-bad:0.10
 		media-libs/gst-plugins-base:0.10
@@ -63,8 +69,9 @@ src_prepare() {
 }
 
 src_configure() {
-	local myqmakeargs=(
-		$(usex gstreamer 'GST_VERSION=0.10' '')
-	)
+		local myqmakeargs=(
+			$(usex gstreamer 'GST_VERSION=1.0' '')
+			$(usex gstreamer010 'GST_VERSION=0.10' '')
+		)
 	qt5-build_src_configure
 }


### PR DESCRIPTION
I tried compiling under gstreamer 1.0 and gstreamer 0.10 and works good. Gstreamer1.0 under QtMultimedia and QtWebkit using USE multimedia use flag works good (tested with QupZilla with videos).

Kwin from gentoo upstream seems to not like really this change (expect gstreamer USE flag and not gstreamer010), but I can confirm using gstreamer1.0 works very good (USE flag  gstreamer as supported by Kwin)