### PR TITLE
Fix for building on non-glibc (musl/uclibc).

### DIFF
--- a/dev-qt/qtnetwork/files/qtnetwork-5.5-socklen_t.patch
+++ b/dev-qt/qtnetwork/files/qtnetwork-5.5-socklen_t.patch
@@ -1,0 +1,17 @@
+diff -Naur a/qtbase-opensource-src-5.5.0/mkspecs/linux-g++/qplatformdefs.h b/qtbase-opensource-src-5.5.0/mkspecs/linux-g++/qplatformdefs.h
+--- a/qtbase-opensource-src-5.5.0/mkspecs/linux-g++/qplatformdefs.h	2015-06-29 17:05:08.000000000 -0300
++++ b/qtbase-opensource-src-5.5.0/mkspecs/linux-g++/qplatformdefs.h	2015-09-29 10:16:03.283745918 -0300
+@@ -78,10 +78,10 @@
+ 
+ #undef QT_SOCKLEN_T
+ 
+-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
+-#define QT_SOCKLEN_T            socklen_t
+-#else
++#if defined(__GLIBC__) && (__GLIBC__ < 2)
+ #define QT_SOCKLEN_T            int
++#else
++#define QT_SOCKLEN_T            socklen_t
+ #endif
+ 
+ #if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)

--- a/dev-qt/qtnetwork/qtnetwork-5.5.0.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.5.0.ebuild
@@ -44,6 +44,10 @@ pkg_setup() {
 	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
 }
 
+src_prepare() {
+	epatch "${FILESDIR}"/${PN}-5.5-socklen_t.patch
+}
+
 src_configure() {
 	local myconf=(
 		$(use connman || use networkmanager && echo -dbus-linked)

--- a/dev-qt/qtnetwork/qtnetwork-5.5.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.5.9999.ebuild
@@ -44,6 +44,10 @@ pkg_setup() {
 	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
 }
 
+src_prepare() {
+	epatch "${FILESDIR}"/${PN}-5.5-socklen_t.patch
+}
+
 src_configure() {
 	local myconf=(
 		$(use connman || use networkmanager && echo -dbus-linked)


### PR DESCRIPTION
This patch is being accepted by upstream for the 5.6 branch, but will
not be backported.  Therefore I have created these patches for the 5.5 branch.