### PR TITLE
sets/lxqt-live: update lxqt-openssh-askpass location

### DIFF
--- a/sets/lxqt-live
+++ b/sets/lxqt-live
@@ -17,7 +17,7 @@
 ~lxqt-base/lxqt-qtplugin-9999
 ~lxqt-base/lxqt-runner-9999
 ~lxqt-base/lxqt-session-9999
-~net-misc/lxqt-openssh-askpass-9999
+~lxqt-base/lxqt-openssh-askpass-9999
 ~dev-libs/libqtxdg-9999
 ~x11-misc/obconf-qt-9999
 x11-wm/openbox:3


### PR DESCRIPTION
lxqt-openssh-askpass-9999 moved from net-misc/ to lxqt-base/

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>