### PR TITLE
Require new enough Harfbuzz

### DIFF
--- a/dev-qt/qtgui/qtgui-5.6.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.6.9999.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	~dev-qt/qtcore-${PV}
 	media-libs/fontconfig
 	>=media-libs/freetype-2.5.5:2
-	>=media-libs/harfbuzz-0.9.40:=
+	>=media-libs/harfbuzz-1.0.6:=
 	>=sys-libs/zlib-1.2.5
 	virtual/opengl
 	dbus? ( ~dev-qt/qtdbus-${PV} )

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	~dev-qt/qtcore-${PV}
 	media-libs/fontconfig
 	>=media-libs/freetype-2.5.5:2
-	>=media-libs/harfbuzz-0.9.40:=
+	>=media-libs/harfbuzz-1.0.6:=
 	>=sys-libs/zlib-1.2.5
 	virtual/opengl
 	dbus? ( ~dev-qt/qtdbus-${PV} )


### PR DESCRIPTION
This got changed in the 5.6 branch in commit
4f8c75acbd7598ee5664b558293fb542817e0091. The listed requirement is on
0.9.42, but in Gentoo we already have 1.0.6 in the tree, and it's what I
build-tested against.