### PR TITLE
Remove openvg from default qt4 set

### DIFF
--- a/sets/qt4
+++ b/sets/qt4
@@ -17,7 +17,7 @@ dev-qt/qtgui:4
 dev-qt/qthelp:4
 dev-qt/qtmultimedia:4
 dev-qt/qtopengl:4
-dev-qt/qtopenvg:4
+#dev-qt/qtopenvg:4
 #dev-qt/qtphonon:4
 dev-qt/qtscript:4
 dev-qt/qtsql:4


### PR DESCRIPTION
This isn't really useful on desktop, and can cause issues with mesa as it pulls in egl support

Given that these features are only really useful on embedded, it's best to leave this out of the default set and have the user pull in manually if desired