### PR TITLE
dev-qt/qtnetwork : Libressl support for 5.7

### DIFF
--- a/dev-qt/qtnetwork/files/qtnetwork-5.7-libressl.patch
+++ b/dev-qt/qtnetwork/files/qtnetwork-5.7-libressl.patch
@@ -1,0 +1,53 @@
+From 81494e67eccba04fc3fe554d76a9ca6fe7f2250e Mon Sep 17 00:00:00 2001
+From: hasufell <hasufell@gentoo.org>
+Date: Sat, 10 Oct 2015 01:15:01 +0200
+Subject: [PATCH] Fix compilation with libressl
+
+By additionally checking for defined(SSL_CTRL_SET_CURVES), which
+is defined in openssl, but not in libressl.
+---
+ src/network/ssl/qsslcontext_openssl.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/network/ssl/qsslcontext_openssl.cpp b/src/network/ssl/qsslcontext_openssl.cpp
+index b88ab54..cfc4f6d 100644
+--- a/src/network/ssl/qsslcontext_openssl.cpp
++++ b/src/network/ssl/qsslcontext_openssl.cpp
+@@ -338,7 +338,7 @@ init_context:
+ 
+     const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();
+     if (!qcurves.isEmpty()) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         // Set the curves to be used
+         if (q_SSLeay() >= 0x10002000L) {
+             // SSL_CTX_ctrl wants a non-const pointer as last argument,
+@@ -352,7 +352,7 @@ init_context:
+                 return sslContext;
+             }
+         } else
+-#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
++#endif // OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_SET_CURVES) && !defined(OPENSSL_NO_EC)
+         {
+             // specific curves requested, but not possible to set -> error
+             sslContext->errorStr = msgErrorSettingEllipticCurves(QSslSocket::tr("OpenSSL version too old, need at least v1.0.2"));
+-- 
+2.6.0
+
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols_p.h b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+index b88ab54..cfc4f6d 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
++++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+492c492
+< #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+---
+> #if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_GET_SERVER_TMP_KEY)
+
+diff --git a/src/network/ssl/qsslsocket_openssl.cpp b/src/network/ssl/qsslsocket_openssl.cpp
+index b88ab54..cfc4f6d 100644
+--- a/src/network/ssl/qsslsocket_openssl.cpp
++++ b/src/network/ssl/qsslsocket_openssl.cpp
+1581c1581
+< #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+---
+> #if OPENSSL_VERSION_NUMBER >= 0x10002000L && defined(SSL_CTRL_GET_SERVER_TMP_KEY)

--- a/dev-qt/qtnetwork/qtnetwork-5.7.0.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.7.0.ebuild
@@ -12,7 +12,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="bindist connman libproxy networkmanager +ssl"
+IUSE="bindist connman libproxy networkmanager +ssl libressl"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
@@ -20,7 +20,10 @@ DEPEND="
 	connman? ( ~dev-qt/qtdbus-${PV} )
 	libproxy? ( net-libs/libproxy )
 	networkmanager? ( ~dev-qt/qtdbus-${PV} )
-	ssl? ( dev-libs/openssl:0[bindist=] )
+	ssl? (
+        !libressl? ( dev-libs/openssl:0 )
+        libressl? ( dev-libs/libressl )
+    )
 "
 RDEPEND="${DEPEND}
 	connman? ( net-misc/connman )
@@ -45,6 +48,9 @@ pkg_setup() {
 }
 
 src_configure() {
+	if use libressl ; then 
+		epatch "${FILESDIR}/${PN}-5.7-libressl.patch"
+	fi
 	local myconf=(
 		$(use connman || use networkmanager && echo -dbus-linked)
 		$(qt_use libproxy)


### PR DESCRIPTION
Dirty but working support for LibreSSL on QtNetwork 5.7.