### PR TITLE
dev-qt/qtwebengine Adding svc requirement for libvpx

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.6.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.6.9999.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	media-libs/freetype
 	media-libs/harfbuzz:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.4:=
+	>=media-libs/libvpx-1.4:=[svc]
 	media-libs/libwebp:=
 	media-libs/mesa
 	media-libs/opus

--- a/dev-qt/qtwebengine/qtwebengine-5.7.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.9999.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	media-libs/freetype
 	media-libs/harfbuzz:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.4:=
+	>=media-libs/libvpx-1.4:=[svc]
 	media-libs/libwebp:=
 	media-libs/mesa
 	media-libs/opus

--- a/dev-qt/qtwebengine/qtwebengine-5.8.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.8.9999.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	media-libs/freetype
 	media-libs/harfbuzz:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.4:=
+	>=media-libs/libvpx-1.4:=[svc]
 	media-libs/libwebp:=
 	media-libs/mesa
 	media-libs/opus

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	media-libs/freetype
 	media-libs/harfbuzz:=
 	media-libs/libpng:0=
-	>=media-libs/libvpx-1.4:=
+	>=media-libs/libvpx-1.4:=[svc]
 	media-libs/libwebp:=
 	media-libs/mesa
 	media-libs/opus


### PR DESCRIPTION
Compiling libvpx without svc USE flag will display:

Checking for libcap... yes
Checking for libvpx... no
Checking for snappy... yes
Checking for srtp... yes
Compatible system libvpx not found. Using Chromium's copy.

That's because Chromium requires a libvpx compiled with svc support. Compiling again qtwebengine using svc USE flag for libvpx will return:

Checking for khr... yes
Checking for libcap... yes
Checking for libvpx... yes
Checking for snappy... yes
Checking for srtp... yes

Information about this requirement at qtwebengine commit http://code.qt.io/cgit/qt/qtwebengine.git/commit/tools/qmake/mkspecs/features/configure.prf?id=3d698f5de377bde2293e222536bc50171cfdf1b8
