### PR TITLE
dev-qt/qtcore: Fix installing 5.6.9999 and 5.7.9999.

### DIFF
--- a/dev-qt/qtcore/qtcore-5.6.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.6.9999.ebuild
@@ -25,6 +25,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
+	doc
 	src/tools/bootstrap
 	src/tools/moc
 	src/tools/rcc

--- a/dev-qt/qtcore/qtcore-5.7.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.7.9999.ebuild
@@ -26,6 +26,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
+	doc
 	src/tools/bootstrap
 	src/tools/moc
 	src/tools/rcc

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -283,9 +283,18 @@ qt5-build_src_install() {
 			qmake_install_target=sub-qmake-qmake-aux-pro-install_subtargets
 		fi
 
-		set -- emake INSTALL_ROOT="${D}" \
-			${qmake_install_target} \
-			install_{syncqt,mkspecs,global_docs}
+		if [[ ${QT5_MINOR_VERSION} -ge 6 ]] && [[ ${QT5_MINOR_VERSION} -lt 8 ]]; then
+
+			set -- emake INSTALL_ROOT="${D}" \
+				${qmake_install_target} \
+				install_{syncqt,mkspecs}
+			else
+
+			set -- emake INSTALL_ROOT="${D}" \
+				${qmake_install_target} \
+				install_{syncqt,mkspecs,global_docs}
+		fi
+
 		einfo "Running $*"
 		"$@"
 


### PR DESCRIPTION
Fixes install-phase that was broken due to the following upstream change:

http://code.qt.io/cgit/qt/qtbase.git/commit/?id=a7ddef139415f74f9ba8dc84a2f15105149ca5e8

Gentoo-Bug: https://bugs.gentoo.org/596054

Have not tested 5.6.9999 outside of an 'ebuild install' run, which went fine, and I really don't know if this is a good fix to put in place or not.

I took a stab at it, and since it seems to work OK here so far, I decided to share.  :]
