### PR TITLE
Introduce qt_use_disable_config

### DIFF
--- a/dev-qt/qtgui/qtgui-5.8.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.8.9999.ebuild
@@ -15,7 +15,7 @@ fi
 # TODO: linuxfb
 
 IUSE="accessibility dbus egl eglfs evdev +gif gles2 gtk
-	ibus jpeg libinput +png tslib tuio +udev +xcb"
+	ibus jpeg libinput +png tslib tuio +udev vnc +xcb"
 REQUIRED_USE="
 	|| ( eglfs xcb )
 	accessibility? ( dbus xcb )
@@ -56,6 +56,7 @@ RDEPEND="
 	tslib? ( x11-libs/tslib )
 	tuio? ( ~dev-qt/qtnetwork-${PV} )
 	udev? ( virtual/libudev:= )
+	vnc? ( ~dev-qt/qtnetwork-${PV} )
 	xcb? (
 		x11-libs/libICE
 		x11-libs/libSM
@@ -137,12 +138,14 @@ src_prepare() {
 	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
 		src/platformsupport/platformsupport.pro || die
 
+	qt_use_disable_config tuio udpsocket src/plugins/generic/generic.pro
+
 	qt_use_disable_mod ibus dbus \
 		src/plugins/platforminputcontexts/platforminputcontexts.pro
 
 	# avoid automagic dep on qtnetwork
-	use tuio || sed -i -e '/SUBDIRS += tuiotouch/d' \
-		src/plugins/generic/generic.pro || die
+	use vnc || sed -i -e '/SUBDIRS += vnc/d' \
+		src/plugins/platforms/platforms.pro || die
 
 	qt5-build_src_prepare
 }

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -15,7 +15,7 @@ fi
 # TODO: linuxfb
 
 IUSE="accessibility dbus egl eglfs evdev +gif gles2 gtk
-	ibus jpeg libinput +png tslib tuio +udev +xcb"
+	ibus jpeg libinput +png tslib tuio +udev vnc +xcb"
 REQUIRED_USE="
 	|| ( eglfs xcb )
 	accessibility? ( dbus xcb )
@@ -56,6 +56,7 @@ RDEPEND="
 	tslib? ( x11-libs/tslib )
 	tuio? ( ~dev-qt/qtnetwork-${PV} )
 	udev? ( virtual/libudev:= )
+	vnc? ( ~dev-qt/qtnetwork-${PV} )
 	xcb? (
 		x11-libs/libICE
 		x11-libs/libSM
@@ -137,12 +138,14 @@ src_prepare() {
 	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
 		src/platformsupport/platformsupport.pro || die
 
+	qt_use_disable_config tuio udpsocket src/plugins/generic/generic.pro
+
 	qt_use_disable_mod ibus dbus \
 		src/plugins/platforminputcontexts/platforminputcontexts.pro
 
 	# avoid automagic dep on qtnetwork
-	use tuio || sed -i -e '/SUBDIRS += tuiotouch/d' \
-		src/plugins/generic/generic.pro || die
+	use vnc || sed -i -e '/SUBDIRS += vnc/d' \
+		src/plugins/platforms/platforms.pro || die
 
 	qt5-build_src_prepare
 }

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -388,6 +388,29 @@ qt_use_compile_test() {
 	fi
 }
 
+# @FUNCTION: qt_use_disable_config
+# @USAGE: <flag> <config> <files...>
+# @DESCRIPTION:
+# <flag> is the name of a flag in IUSE.
+# <config> is the (lowercase) name of a Qt5 config entry.
+# <files...> is a list of one or more qmake project files.
+#
+# This function patches <files> to treat <config> as disabled
+# when <flag> is disabled, otherwise it does nothing.
+# This can be useful to avoid an automagic dependency when the config entry
+# is enabled on the system but the corresponding USE flag is disabled.
+qt_use_disable_config() {
+	[[ $# -ge 3 ]] || die "${FUNCNAME}() requires at least three arguments"
+
+	local flag=$1
+	local config=$2
+	shift 2
+
+	if ! use "${flag}"; then
+		echo "$@" | xargs sed -i -e "s/qtConfig(${config})/false/g" || die
+	fi
+}
+
 # @FUNCTION: qt_use_disable_mod
 # @USAGE: <flag> <module> <files...>
 # @DESCRIPTION:


### PR DESCRIPTION
In qt/qtbase@a668c6a6, ``!contains(QT_DISABLED_FEATURES, udpsocket) {
     SUBDIRS += tuiotouch
 } `` became ``
qtConfig(udpsocket) {
     SUBDIRS += tuiotouch
 }
``

``qtConfig`` appears to be defined such that if the feature status is undefined, it dies (``error("Could not find feature $${1}.")``).

This introduces ``qt_use_disable_config``, a clone of ``qt_use_disable_mod`` to handle this new style of automagic dependency.