### PR TITLE
dev-qt/qtgui: move gtk platform plugin to qtwidgets

### DIFF
--- a/dev-qt/qtgui/qtgui-5.8.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.8.9999.ebuild
@@ -14,8 +14,8 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 gtk
-	ibus jpeg libinput +png tslib tuio +udev vnc +xcb"
+IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus
+	jpeg libinput +png tslib tuio +udev vnc +xcb"
 REQUIRED_USE="
 	|| ( eglfs xcb )
 	accessibility? ( dbus xcb )
@@ -40,12 +40,6 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gtk? (
-		x11-libs/gtk+:3
-		x11-libs/libX11
-		x11-libs/pango
-		!!x11-libs/cairo[qt4]
-	)
 	gles2? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
@@ -88,7 +82,6 @@ QT5_TARGET_SUBDIRS=(
 	src/plugins/imageformats
 	src/plugins/platforms
 	src/plugins/platforminputcontexts
-	src/plugins/platformthemes
 )
 
 QT5_GENTOO_CONFIG=(
@@ -105,7 +98,6 @@ QT5_GENTOO_CONFIG=(
 	!gif:no-gif:
 	gles2::OPENGL_ES
 	gles2:opengles2:OPENGL_ES_2
-	gtk:gtk3:
 	!:no-gui:
 	:system-harfbuzz:HARFBUZZ
 	!:no-harfbuzz:
@@ -159,7 +151,6 @@ src_configure() {
 		-fontconfig
 		-system-freetype
 		$(usex gif '' -no-gif)
-		$(qt_use gtk)
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -14,8 +14,8 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 gtk
-	ibus jpeg libinput +png tslib tuio +udev vnc +xcb"
+IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus
+	jpeg libinput +png tslib tuio +udev vnc +xcb"
 REQUIRED_USE="
 	|| ( eglfs xcb )
 	accessibility? ( dbus xcb )
@@ -40,12 +40,6 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gtk? (
-		x11-libs/gtk+:3
-		x11-libs/libX11
-		x11-libs/pango
-		!!x11-libs/cairo[qt4]
-	)
 	gles2? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
@@ -88,7 +82,6 @@ QT5_TARGET_SUBDIRS=(
 	src/plugins/imageformats
 	src/plugins/platforms
 	src/plugins/platforminputcontexts
-	src/plugins/platformthemes
 )
 
 QT5_GENTOO_CONFIG=(
@@ -105,7 +98,6 @@ QT5_GENTOO_CONFIG=(
 	!gif:no-gif:
 	gles2::OPENGL_ES
 	gles2:opengles2:OPENGL_ES_2
-	gtk:gtk3:
 	!:no-gui:
 	:system-harfbuzz:HARFBUZZ
 	!:no-harfbuzz:
@@ -159,7 +151,6 @@ src_configure() {
 		-fontconfig
 		-system-freetype
 		$(usex gif '' -no-gif)
-		$(qt_use gtk)
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)

--- a/dev-qt/qtwidgets/metadata.xml
+++ b/dev-qt/qtwidgets/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gtk">Build the GTK platform theme plugin</flag>
 		<flag name="gtkstyle">Build a Qt style called GTK+ that mimics the active
 			GTK+ theme</flag>
 	</use>

--- a/dev-qt/qtwidgets/qtwidgets-5.8.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.8.9999.ebuild
@@ -13,26 +13,35 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 +png +xcb"
+IUSE="gles2 gtk +png +xcb"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtgui-${PV}[gles2=,png=,xcb?]
+	gtk? (
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/pango
+		!!x11-libs/cairo[qt4]
+	)
 "
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
 	src/tools/uic
 	src/widgets
+	src/plugins/platformthemes
 )
 
 QT5_GENTOO_CONFIG=(
+	gtk:gtk3:
 	!:no-widgets:
 )
 
 src_configure() {
 	local myconf=(
 		-opengl $(usex gles2 es2 desktop)
+		$(qt_use gtk)
 		$(qt_use png libpng system)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon system)

--- a/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
@@ -13,26 +13,35 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 +png +xcb"
+IUSE="gles2 gtk +png +xcb"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtgui-${PV}[gles2=,png=,xcb?]
+	gtk? (
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/pango
+		!!x11-libs/cairo[qt4]
+	)
 "
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
 	src/tools/uic
 	src/widgets
+	src/plugins/platformthemes
 )
 
 QT5_GENTOO_CONFIG=(
+	gtk:gtk3:
 	!:no-widgets:
 )
 
 src_configure() {
 	local myconf=(
 		-opengl $(usex gles2 es2 desktop)
+		$(qt_use gtk)
 		$(qt_use png libpng system)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon system)


### PR DESCRIPTION
src/plugins/platformthemes/platformthemes.pro now looks like this:

```TEMPLATE = subdirs
QT_FOR_CONFIG += widgets-private

qtHaveModule(widgets):qtConfig(gtk3): SUBDIRS += gtk3
```