### PR TITLE
qt5-build.eclass: fix avoiding qmake recompilation for Qt 5.8 and later

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.6.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.6.9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/dev-qt/qtwebengine/qtwebengine-5.7.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.7.9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/dev-qt/qtwebengine/qtwebengine-5.8.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.8.9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 	media-libs/mesa
 	media-libs/opus
 	media-libs/speex
-	net-libs/libsrtp:=
+	net-libs/libsrtp:0=
 	sys-apps/dbus
 	sys-apps/pciutils
 	sys-libs/libcap

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -179,8 +179,14 @@ qt5-build_src_prepare() {
 		qt5_symlink_tools_to_build_dir
 
 		# Avoid unnecessary qmake recompilations
-		sed -i -re "s|^if true;.*(\[ '\!').*(\"\\\$outpath/bin/qmake\".*)|if \1 -e \2 then|" \
-			configure || die "sed failed (skip qmake bootstrap)"
+		if [[ ${QT5_MINOR_VERSION} -ge 8 ]]; then
+			sed -i -e "/Creating qmake/i if [ '!' -e \"\$outpath/bin/qmake\" ]; then" \
+				-e '/echo "Done."/a fi' \
+				configure || die "sed failed (skip qmake bootstrap)"
+		else
+			sed -i -re "s|^if true;.*(\[ '\!').*(\"\\\$outpath/bin/qmake\".*)|if \1 -e \2 then|" \
+				configure || die "sed failed (skip qmake bootstrap)"
+		fi
 
 		# Respect CC, CXX, *FLAGS, MAKEOPTS and EXTRA_EMAKE when bootstrapping qmake
 		sed -i -e "/outpath\/qmake\".*\"\$MAKE\")/ s:): \


### PR DESCRIPTION
The old hack is no longer possible since qt/qtbase@4ce0beee1b69a8695fc24a244a8a3053711906ac. This is a much worse hack but I'm not sure what other option we have.