### PR TITLE
dev-qt/qtdbus: Adjust the awful hack to make 'qtdbus' build.

### DIFF
--- a/dev-qt/qtdbus/qtdbus-5.8.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.8.9999.ebuild
@@ -53,7 +53,7 @@ src_compile() {
 	hack() {
 		emake
 		if [[ ${subdir} = "src/corelib" ]]; then
-			rm "${S}"/lib/libQt5Core* || die
+			rm "${QT5_BUILD_DIR}"/lib/libQt5Core* || die
 		fi
 	}
 	qt5_foreach_target_subdir hack

--- a/dev-qt/qtdbus/qtdbus-5.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.9999.ebuild
@@ -53,7 +53,7 @@ src_compile() {
 	hack() {
 		emake
 		if [[ ${subdir} = "src/corelib" ]]; then
-			rm "${S}"/lib/libQt5Core* || die
+			rm "${QT5_BUILD_DIR}"/lib/libQt5Core* || die
 		fi
 	}
 	qt5_foreach_target_subdir hack


### PR DESCRIPTION
For the live-builds, the files we want to remove will be under the build directory, not the source directory.  Without this change, the files are not found.

For at least 5.8.0, it seems like it might be enough to have the 'src/corelib' added to 'QT5_TARGET_SUBDIRS'.  I'm not super sure of that yet, so I may be missing something more or/and less obvious.
