### PR TITLE
Fix configure for {5,5.8}.9999 'qtbase' packages.

### DIFF
--- a/dev-qt/qtgui/qtgui-5.8.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.8.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -55,7 +55,6 @@ RDEPEND="
 		x11-libs/libSM
 		x11-libs/libX11
 		>=x11-libs/libXi-1.7.4
-		x11-libs/libXrender
 		>=x11-libs/libxcb-1.10:=[xkb]
 		>=x11-libs/libxkbcommon-0.4.1[X]
 		x11-libs/xcb-util-image
@@ -118,7 +117,6 @@ QT5_GENTOO_CONFIG=(
 	xcb:xcb-xlib:
 	xcb:xinput2:
 	xcb::XKB
-	xcb:xrender
 )
 
 src_prepare() {
@@ -160,7 +158,7 @@ src_configure() {
 		$(qt_use udev libudev)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon-x11 system)
-		$(usex xcb '-xcb-xlib -xinput2 -xkb -xrender' '')
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -55,7 +55,6 @@ RDEPEND="
 		x11-libs/libSM
 		x11-libs/libX11
 		>=x11-libs/libXi-1.7.4
-		x11-libs/libXrender
 		>=x11-libs/libxcb-1.10:=[xkb]
 		>=x11-libs/libxkbcommon-0.4.1[X]
 		x11-libs/xcb-util-image
@@ -118,7 +117,6 @@ QT5_GENTOO_CONFIG=(
 	xcb:xcb-xlib:
 	xcb:xinput2:
 	xcb::XKB
-	xcb:xrender
 )
 
 src_prepare() {
@@ -160,7 +158,7 @@ src_configure() {
 		$(qt_use udev libudev)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon-x11 system)
-		$(usex xcb '-xcb-xlib -xinput2 -xkb -xrender' '')
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwidgets/qtwidgets-5.8.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.8.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -43,7 +43,7 @@ src_configure() {
 		$(qt_use png libpng system)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon system)
-		$(usex xcb '-xcb-xlib -xinput2 -xkb -xrender' '')
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -43,7 +43,7 @@ src_configure() {
 		$(qt_use png libpng system)
 		$(qt_use xcb xcb system)
 		$(qt_use xcb xkbcommon system)
-		$(usex xcb '-xcb-xlib -xinput2 -xkb -xrender' '')
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
 	)
 	qt5-build_src_configure
 }

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -654,7 +654,9 @@ qt5_base_configure() {
 
 		# disable undocumented X11-related flags, override in qtgui
 		# (not shown in ./configure -help output)
-		-no-xkb -no-xrender
+		-no-xkb
+		$([[ ${QT5_MINOR_VERSION} -lt 8 || ${QT5_MINOR_VERSION} -eq 8
+			&& ${QT5_PATCH_VERSION} -lt 1 ]] && echo -no-xrender)
 
 		# disable obsolete/unused X11-related flags
 		$([[ ${QT5_MINOR_VERSION} -lt 8 ]] && echo -no-mitshm -no-xcursor -no-xfixes -no-xrandr -no-xshape -no-xsync)


### PR DESCRIPTION
Upstream has removed an “unused Xlib's XRender dependency”, which results into 'qtcore-5.8.9999' and 'qtgui-5.8.9999' configure phases failing due to an unknown command line option (-xrender or -no-xrender).

http://code.qt.io/cgit/qt/qtbase.git/commit/?id=d37c353dc0f2ae5bb803fe9e5752eff846246439
