### PR TITLE
PySide2: From the Dead We Shall Resurrect You

### DIFF
--- a/dev-python/pyside/metadata.xml
+++ b/dev-python/pyside/metadata.xml
@@ -6,18 +6,26 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="X">Build QtGui and QtTest modules</flag>
-		<flag name="declarative">Build QtDeclarative module</flag>
+		<flag name="concurrent">Build QtConcurrent module</flag>
+		<flag name="declarative">Build QtQml, QtQuick, and QtQuickWidgets modules</flag>
 		<flag name="designer">Build QtDesigner and QtUiTools modules</flag>
+		<flag name="gui">Build QtGui module</flag>
 		<flag name="help">Build QtHelp module</flag>
 		<flag name="multimedia">Build QtMultimedia module</flag>
+		<flag name="network">Build QtNetwork module</flag>
 		<flag name="opengl">Build QtOpenGL module</flag>
+		<flag name="printsupport">Build QtPrintSupport module</flag>
 		<flag name="script">Build QtScript module</flag>
 		<flag name="scripttools">Build QtScriptTools module</flag>
 		<flag name="sql">Build QtSql module</flag>
 		<flag name="svg">Build QtSvg module</flag>
-		<flag name="webkit">Build QtWebKit module</flag>
+		<flag name="testlib">Build QtTest module</flag>
+		<flag name="webchannel">Build QtWebChannel module</flag>
+		<flag name="webengine">Build QtWebEngine and QtWebEngineWidgets modules</flag>
+		<flag name="webkit">Build QtWebKit and QtWebKitWidgets modules</flag>
+		<flag name="websockets">Build QtWebSockets module</flag>
+		<flag name="widgets">Build QtWidgets module</flag>
+		<flag name="x11extras">Build QtX11Extras module</flag>
 		<flag name="xmlpatterns">Build QtXmlPatterns module</flag>
 	</use>
 </pkgmetadata>
-

--- a/dev-python/pyside/pyside-9999.ebuild
+++ b/dev-python/pyside/pyside-9999.ebuild
@@ -1,71 +1,97 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
 inherit cmake-utils flag-o-matic python-r1 virtualx git-r3
 
 DESCRIPTION="Python bindings for the Qt framework"
-HOMEPAGE="https://wiki.qt.io/Pyside"
+HOMEPAGE="https://wiki.qt.io/PySide2"
 EGIT_REPO_URI=(
-	"git://code.qt.io/pyside/${PN}.git"
-	"https://code.qt.io/git/pyside/${PN}.git"
+	"git://code.qt.io/pyside/pyside.git"
+	"https://code.qt.io/git/pyside/pyside.git"
 )
 
+#FIXME: Switch to the clang-enabled "dev" branch once stable.
+EGIT_BRANCH="5.6"
+
 LICENSE="LGPL-2.1"
-SLOT="0"
+SLOT="2"
 KEYWORDS=""
 
-IUSE="X declarative designer help multimedia opengl script scripttools sql svg test webkit xmlpatterns"
+IUSE="
+	concurrent declarative designer gui help multimedia network opengl
+	printsupport script scripttools sql svg test testlib webchannel webengine
+	webkit websockets widgets x11extras xmlpatterns"
+
+# The requirements below were strongly inspired by their "PyQt5" equivalents.
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
-	declarative? ( X )
-	designer? ( X )
-	help? ( X )
-	multimedia? ( X )
-	opengl? ( X )
-	scripttools? ( X script )
-	sql? ( X )
-	svg? ( X )
-	test? ( X )
-	webkit? ( X )
+	declarative? ( gui network )
+	designer? ( widgets )
+	help? ( widgets )
+	multimedia? ( gui network )
+	opengl? ( widgets )
+	printsupport? ( widgets )
+	scripttools? ( gui script )
+	sql? ( widgets )
+	svg? ( widgets )
+	test? ( widgets )
+	testlib? ( widgets )
+	webchannel? ( network )
+	webengine? ( network webchannel widgets )
+	webkit? ( gui network printsupport widgets )
+	websockets? ( network )
+	widgets? ( gui )
+	xmlpatterns? ( network )
 "
 
-# Minimal supported version of Qt.
-QT_PV="4.8.5:4"
+# Minimum version of Qt required, derived from the "CMakeLists.txt" line:
+#      find_package(Qt5 ${QT_PV} REQUIRED COMPONENTS Core)
+QT_PV=":5/5.6"
 
 RDEPEND="
 	${PYTHON_DEPS}
-	>=dev-python/shiboken-${PV}[${PYTHON_USEDEP}]
-	>=dev-qt/qtcore-${QT_PV}
-	X? (
-		>=dev-qt/qtgui-${QT_PV}[accessibility]
-		>=dev-qt/qttest-${QT_PV}
-	)
-	declarative? ( >=dev-qt/qtdeclarative-${QT_PV} )
-	designer? ( >=dev-qt/designer-${QT_PV} )
-	help? ( >=dev-qt/qthelp-${QT_PV} )
-	multimedia? ( >=dev-qt/qtmultimedia-${QT_PV} )
-	opengl? ( >=dev-qt/qtopengl-${QT_PV} )
-	script? ( >=dev-qt/qtscript-${QT_PV} )
-	sql? ( >=dev-qt/qtsql-${QT_PV} )
-	svg? ( >=dev-qt/qtsvg-${QT_PV}[accessibility] )
-	webkit? ( >=dev-qt/qtwebkit-${QT_PV} )
-	xmlpatterns? ( >=dev-qt/qtxmlpatterns-${QT_PV} )
+	>=dev-python/shiboken-${PV}:${SLOT}[${PYTHON_USEDEP}]
+	dev-qt/qtcore${QT_PV}
+	dev-qt/qtxml${QT_PV}
+	declarative? ( dev-qt/qtdeclarative${QT_PV}[widgets?] )
+	designer? ( dev-qt/designer${QT_PV} )
+	help? ( dev-qt/qthelp${QT_PV} )
+	multimedia? ( dev-qt/qtmultimedia${QT_PV}[widgets?] )
+	opengl? ( dev-qt/qtopengl${QT_PV} )
+	printsupport? ( dev-qt/qtprintsupport${QT_PV} )
+	script? ( dev-qt/qtscript${QT_PV} )
+	sql? ( dev-qt/qtsql${QT_PV} )
+	svg? ( dev-qt/qtsvg${QT_PV} )
+	testlib? ( dev-qt/qttest${QT_PV} )
+	webchannel? ( dev-qt/qtwebchannel${QT_PV} )
+	webengine? ( dev-qt/qtwebengine${QT_PV}[widgets?] )
+	webkit? ( dev-qt/qtwebkit${QT_PV}[printsupport] )
+	websockets? ( dev-qt/qtwebsockets${QT_PV} )
+	x11extras? ( dev-qt/qtx11extras${QT_PV} )
+	xmlpatterns? ( dev-qt/qtxmlpatterns${QT_PV} )
+	concurrent? ( dev-qt/qtconcurrent${QT_PV} )
+	gui? ( dev-qt/qtgui${QT_PV} )
+	network? ( dev-qt/qtnetwork${QT_PV} )
+	printsupport? ( dev-qt/qtprintsupport${QT_PV} )
+	sql? ( dev-qt/qtsql${QT_PV} )
+	testlib? ( dev-qt/qttest${QT_PV} )
+	widgets? ( dev-qt/qtwidgets${QT_PV} )
 "
-DEPEND="${RDEPEND}
-	>=dev-qt/qtgui-${QT_PV}
-"
-
-DOCS=( ChangeLog )
+DEPEND="${RDEPEND}"
 
 src_prepare() {
-	# Fix generated pkgconfig file to require the shiboken
-	# library suffixed with the correct python version.
-	sed -i -e '/^Requires:/ s/shiboken$/&@SHIBOKEN_PYTHON_SUFFIX@/' \
-		libpyside/pyside2.pc.in || die
+	#FIXME: Remove the following "sed" patch after this upstream issue is closed:
+	#    https://bugreports.qt.io/browse/PYSIDE-502
+	
+	# Force the optional "Qt5Concurrent", "Qt5Gui", "Qt5Network",
+	# "Qt5PrintSupport", "Qt5Sql", "Qt5Test", and "Qt5Widgets" packages
+	# erroneously marked as mandatory to be optional.
+	sed -i -e 's/^\(CHECK_PACKAGE_FOUND(Qt5\(Concurrent\|Gui\|Network\|PrintSupport\|Sql\|Test\|Widgets\)\))$/\1 opt)/' \
+		PySide2/CMakeLists.txt || die
 
 	if use prefix; then
 		cp "${FILESDIR}"/rpath.cmake . || die
@@ -76,25 +102,38 @@ src_prepare() {
 }
 
 src_configure() {
-	append-cxxflags -std=c++11
-
+	# For each line of the form "CHECK_PACKAGE_FOUND(${PACKAGE_NAME} opt)" in
+	# "PySide2/CMakeLists.txt" defining an optional dependency, an option of the
+	# form "-DCMAKE_DISABLE_FIND_PACKAGE_${PACKAGE_NAME}=$(usex !${USE_FLAG})"
+	# is passed to "cmake" here conditionally disabling this dependency.
 	local mycmakeargs=(
 		-DBUILD_TESTS=$(usex test)
-		-DDISABLE_QtGui=$(usex !X)
-		-DDISABLE_QtTest=$(usex !X)
-		-DDISABLE_QtQml=$(usex !declarative)
-		-DDISABLE_QtQuick=$(usex !declarative)
-		-DDISABLE_QtQuickWidgets=$(usex !declarative)
-		-DDISABLE_QtUiTools=$(usex !designer)
-		-DDISABLE_QtHelp=$(usex !help)
-		-DDISABLE_QtMultimedia=$(usex !multimedia)
-		-DDISABLE_QtOpenGL=$(usex !opengl)
-		-DDISABLE_QtScript=$(usex !script)
-		-DDISABLE_QtScriptTools=$(usex !scripttools)
-		-DDISABLE_QtSql=$(usex !sql)
-		-DDISABLE_QtSvg=$(usex !svg)
-		-DDISABLE_QtWebKit=$(usex !webkit)
-		-DDISABLE_QtXmlPatterns=$(usex !xmlpatterns)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Concurrent=$(usex !concurrent)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Gui=$(usex !gui)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Designer=$(usex !designer)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5UiTools=$(usex !designer)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Help=$(usex !help)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Multimedia=$(usex !multimedia)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Network=$(usex !network)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5OpenGL=$(usex !opengl)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Qml=$(usex !declarative)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Quick=$(usex !declarative)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5QuickWidgets=$(usex !declarative)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5PrintSupport=$(usex !printsupport)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Script=$(usex !script)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5ScriptTools=$(usex !scripttools)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Sql=$(usex !sql)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Svg=$(usex !svg)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Test=$(usex !testlib)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebChannel=$(usex !webchannel)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebEngine=$(usex !webengine)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebEngineWidgets=$(usex !webengine)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebKit=$(usex !webkit)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebKitWidgets=$(usex !webkit)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebSockets=$(usex !websockets)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Widgets=$(usex !widgets)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5X11Extras=$(usex !x11extras)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5XmlPatterns=$(usex !xmlpatterns)
 	)
 
 	configuration() {
@@ -120,7 +159,7 @@ src_test() {
 src_install() {
 	installation() {
 		cmake-utils_src_install
-		mv "${ED}"usr/$(get_libdir)/pkgconfig/${PN}{,-${EPYTHON}}.pc || die
+		mv "${ED}"usr/$(get_libdir)/pkgconfig/${PN}2{,-${EPYTHON}}.pc || die
 	}
 	python_foreach_impl installation
 }

--- a/dev-python/shiboken/shiboken-9999.ebuild
+++ b/dev-python/shiboken/shiboken-9999.ebuild
@@ -1,44 +1,54 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 
-inherit cmake-utils python-r1 git-r3
+inherit cmake-utils llvm python-r1 git-r3
 
-DESCRIPTION="A tool for creating Python bindings for C++ libraries"
-HOMEPAGE="https://wiki.qt.io/Pyside"
+DESCRIPTION="Tool for creating Python bindings for C++ libraries"
+HOMEPAGE="https://wiki.qt.io/PySide2"
 EGIT_REPO_URI=(
-	"git://code.qt.io/pyside/${PN}.git"
-	"https://code.qt.io/git/pyside/${PN}.git"
+	"git://code.qt.io/pyside/shiboken.git"
+	"https://code.qt.io/git/pyside/shiboken.git"
 )
 
+#FIXME: Switch to the clang-enabled "dev" branch once stable.
+EGIT_BRANCH="5.6"
+
 LICENSE="LGPL-2.1"
-SLOT="0"
+SLOT="2"
 KEYWORDS=""
 IUSE="test"
-
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
+# Minimum version of Qt required.
+QT_PV=":5/5.6"
+
+#FIXME: Add "sys-devel/clang:*" after switching to the "dev" branch.
 RDEPEND="
 	${PYTHON_DEPS}
-	dev-libs/libxml2
-	dev-libs/libxslt
-	dev-qt/qtcore:5
-	dev-qt/qtxml:5
-	dev-qt/qtxmlpatterns:5
+	>=dev-libs/libxml2-2.6.32
+	>=dev-libs/libxslt-1.1.19
+	dev-qt/qtcore${QT_PV}
+	dev-qt/qtxml${QT_PV}
+	dev-qt/qtxmlpatterns${QT_PV}
 "
 DEPEND="${RDEPEND}
 	test? (
-		dev-qt/qtgui:5
-		dev-qt/qttest:5
+		dev-qt/qtgui${QT_PV}
+		dev-qt/qttest${QT_PV}
 	)
 "
 
 DOCS=( AUTHORS )
 
 src_prepare() {
+	#FIXME: Uncomment after switching to the "dev" branch.
+	# sed -i -e '/^find_library(CLANG_LIBRARY/ s~/lib)$~/'$(get_libdir)')~' \
+	# 	CMakeLists.txt || die
+
 	if use prefix; then
 		cp "${FILESDIR}"/rpath.cmake . || die
 		sed -i -e '1iinclude(rpath.cmake)' CMakeLists.txt || die
@@ -60,6 +70,13 @@ src_configure() {
 				-DUSE_PYTHON_VERSION=3
 			)
 		fi
+
+		#FIXME: Uncomment after switching to the "dev" branch.
+		#FIXME: "CMakeLists.txt" currently requires that callers manually set
+		#this environment variable to the absolute path of the directory
+		#containing clang libraries rather than magically finding this path
+		#(e.g., via "find_package(CLang)"). If this changes, remove this option.
+		# CLANG_INSTALL_DIR="$(get_llvm_prefix)" cmake-utils_src_configure
 
 		cmake-utils_src_configure
 	}


### PR DESCRIPTION
This pull request fixes all issues reported at [bug 612272](https://bugs.gentoo.org/show_bug.cgi?id=612272) on [Bugzilla](https://bugs.gentoo.org) *and* several other minor issues since uncovered. <sup>*details below*</sup>

Before we begin, I'd like to repeat the opening refrain of that bug report: **thank you.** This overlay is a diamond in the cruft, whose tireless volunteers have made all things possible again. Thanks, all!

## Just Tell Us What's Wrong Already

The current state of the PySide2 ebuild is… *less than desirable.* It's an excellent foundation that currently doesn't work at all. Let's see if we can do something about that.

Outstanding issues include (*in descending order of importance*):

* **Package namespace collision.** This overlay's Qt5-specific `dev-python/pyside` and `dev-python/shiboken` packages collide with Portage's Qt4-specific packages of the same name, preventing PySide1 and PySide2 from being concurrently installed *and* breaking downstream ebuilds requiring only PySide1. PySide1 and PySide2 are similar but ultimately incompatible (much like Python 2 and 3). Porting between the two is feasible but non-trivial. Existing ebuilds requiring `dev-python/pyside` typically expect PySide1 and hence are *not* satisfied by this overlay's `dev-python/pyside-9999` ebuild.
* **All USE flags are currently ignored.** <sup>_It hurts._</sup>
* The new optional `Qt5WebChannel`, `Qt5WebEngineWidgets`, and `Qt5WebSockets` dependencies have no corresponding USE flags.
* The `${QT_PV}` global implies PySide2 to only require Qt >= 4.8.5, when in fact PySide2 requires Qt >= 5.3.0.
* The `${DOCS}` global references a `ChangeLog` file that no longer exists.
* The optional `dev-qt/qtsvg:5` dependency no longer accepts an `accessibility` USE flag.
* The `${PYTHON_COMPAT}` globals incorrectly omit Python 3.6, which is [explicitly supported](https://bugreports.qt.io/browse/PYSIDE-471).
* Ebuild metadata (e.g., `${DESCRIPTION}`, `${HOMEPAGE}`) incorrectly references PySide1.

See the [bug report](https://bugs.gentoo.org/show_bug.cgi?id=612272) for tedious details so boring you'll want to [punch a baby](https://www.youtube.com/watch?v=otn96q_v6P0).

## Just Tell Us What You Did Already

This pull request addresses *most* of the above issues – excluding the new optional dependencies with no USE flags. I just ignored those. I'm lazy and like video games.

Specifically (*in the same order as above*):

* This overlay's Qt5-specific `dev-python/pyside` and `dev-python/shiboken` packages have been moved to `dev-python/pyside2` and `dev-python/shiboken2`, coinciding with upstream path, package, and project names. To facilitate this move, file collisions with users installing the older `dev-python/pyside-9999` and `dev-python/shiboken-9999` ebuilds have been prevented as follows:
  * `dev-python/pyside2-9999` is blocked by `dev-python/pyside-9999`.
  * `dev-python/shiboken2-9999` is blocked by `dev-python/shiboken-9999`.
* All USE flags are now handled as expected. This was probably the least trivial change. In the `src_configure()` phase:
  * Each `cmake` option of the form `-DDISABLE_${DEPENDENCY}=$(usex !${USE_FLAG})` has been converted into an equivalent option of the form `-DCMAKE_DISABLE_FIND_PACKAGE_${DEPENDENCY}=$(usex !X)`. For details on the magic `CMAKE_DISABLE_FIND_PACKAGE_${DEPENDENCY}` global, see CMake's [official documentation](https://cmake.org/cmake/help/v3.0/command/find_package.html) for the `find_package()` function.
  * Each Qt4-specific dependency has been converted into the equivalent Qt5-specific dependency.
  * Several dependencies optional under PySide1 are now mandatory under PySide2, including `Qt5Gui`, `Qt5Sql`, and `Qt5Test`. Yes, that's right: **PySide2 requires both X and SQL support,** at least superficially. I'm inclined to believe that this is an upstream bug. PyQt5 does *not* require SQL and there's little reason to believe that PySide2 should either. This should probably be reported to the [upstream issue tracker](https://bugreports.qt.io/browse/PYSIDE/fixforversion/15785). Until resolved upstream, the PySide2 ebuild now patches the `PySide2/CMakeLists.txt` file to only optionally require these dependencies.
* The `${QT_PV}` global now requires Qt >= 5.3.0.
* The `${DOCS}` global has been deleted.
* The optional `dev-qt/qtsvg:5` dependency is now passed no USE flags.
* Python 3.6 is now supported by both the PySide2 and Shiboken2 ebuilds.
* Ebuild metadata (e.g., `${DESCRIPTION}`, `${HOMEPAGE}`) has been updated.
* Copyright headers have been updated to 2017.

And that's how the cookie was crumbled. :cookie: 