### PR TITLE
dev-qt: Add live ebuilds for the 5.9 branch.

### DIFF
--- a/dev-qt/assistant/assistant-5.9.9999.ebuild
+++ b/dev-qt/assistant/assistant-5.9.9999.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Tool for viewing on-line documentation in Qt help file format"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE="webkit"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qthelp-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtprintsupport-${PV}
+	~dev-qt/qtsql-${PV}[sqlite]
+	~dev-qt/qtwidgets-${PV}
+	webkit? ( ~dev-qt/qtwebkit-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/assistant/assistant
+)
+
+src_prepare() {
+	qt_use_disable_mod webkit webkitwidgets \
+		src/assistant/assistant/assistant.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/designer/designer-5.9.9999.ebuild
+++ b/dev-qt/designer/designer-5.9.9999.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="WYSIWYG tool for designing and building Qt-based GUIs"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="declarative webkit"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtprintsupport-${PV}
+	~dev-qt/qtwidgets-${PV}
+	~dev-qt/qtxml-${PV}
+	declarative? ( ~dev-qt/qtdeclarative-${PV}[widgets] )
+	webkit? ( ~dev-qt/qtwebkit-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/designer
+)
+
+src_prepare() {
+	qt_use_disable_mod declarative quickwidgets \
+		src/designer/src/plugins/plugins.pro
+
+	qt_use_disable_mod webkit webkitwidgets \
+		src/designer/src/plugins/plugins.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/linguist-tools/linguist-tools-5.9.9999.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.9.9999.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Tools for working with Qt translation data files"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="qml"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtxml-${PV}
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/linguist
+)
+
+src_prepare() {
+	sed -i -e '/SUBDIRS += linguist/d' \
+		src/linguist/linguist.pro || die
+
+	qt_use_disable_mod qml qmldevtools-private \
+		src/linguist/lupdate/lupdate.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/linguist/linguist-5.9.9999.ebuild
+++ b/dev-qt/linguist/linguist-5.9.9999.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Graphical tool for translating Qt applications"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/designer-${PV}
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtprintsupport-${PV}
+	~dev-qt/qtwidgets-${PV}
+	~dev-qt/qtxml-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/linguist/linguist
+)

--- a/dev-qt/pixeltool/pixeltool-5.9.9999.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.9.9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Qt screen magnifier"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtwidgets-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/pixeltool
+)

--- a/dev-qt/qdbus/qdbus-5.9.9999.ebuild
+++ b/dev-qt/qdbus/qdbus-5.9.9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Interface to Qt applications communicating over D-Bus"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdbus-${PV}
+	~dev-qt/qtxml-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qdbus/qdbus
+)

--- a/dev-qt/qdbusviewer/qdbusviewer-5.9.9999.ebuild
+++ b/dev-qt/qdbusviewer/qdbusviewer-5.9.9999.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Graphical tool that lets you introspect D-Bus objects and messages"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdbus-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtwidgets-${PV}
+	~dev-qt/qtxml-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qdbus/qdbusviewer
+)

--- a/dev-qt/qdoc/qdoc-5.9.9999.ebuild
+++ b/dev-qt/qdoc/qdoc-5.9.9999.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Qt documentation generator"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="qml"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qdoc
+)
+
+src_prepare() {
+	qt_use_disable_mod qml qmldevtools-private \
+		src/qdoc/qdoc.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qt3d/qt3d-5.9.9999.ebuild
+++ b/dev-qt/qt3d/qt3d-5.9.9999.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="The 3D module for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+# TODO: gamepad, tools
+IUSE="gles2"
+
+DEPEND="
+	~dev-qt/qtconcurrent-${PV}
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	>=media-libs/assimp-3.1.1
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	rm -r src/3rdparty/assimp/{code,contrib,include} || die
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtbluetooth/qtbluetooth-5.9.9999.ebuild
+++ b/dev-qt/qtbluetooth/qtbluetooth-5.9.9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtconnectivity"
+inherit qt5-build
+
+DESCRIPTION="Bluetooth support library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~x86"
+fi
+
+IUSE="qml"
+
+RDEPEND="
+	~dev-qt/qtconcurrent-${PV}
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdbus-${PV}
+	>=net-wireless/bluez-5:=
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+DEPEND="${RDEPEND}
+	~dev-qt/qtnetwork-${PV}
+"
+
+src_prepare() {
+	sed -i -e 's/nfc//' src/src.pro || die
+
+	qt_use_disable_mod qml quick src/src.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtcharts/qtcharts-5.9.9999.ebuild
+++ b/dev-qt/qtcharts/qtcharts-5.9.9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Chart component library for the Qt5 framework"
+LICENSE="GPL-3"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+IUSE="qml"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtwidgets-${PV}
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod qml quick \
+		src/src.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtconcurrent/qtconcurrent-5.9.9999.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.9.9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Multi-threading concurrence support library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/concurrent
+)

--- a/dev-qt/qtcore/qtcore-5.9.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9.9999.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Cross-platform application development framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="icu systemd"
+
+DEPEND="
+	dev-libs/double-conversion:=
+	dev-libs/glib:2
+	dev-libs/libpcre2[pcre16,unicode]
+	sys-libs/zlib
+	icu? ( dev-libs/icu:= )
+	!icu? ( virtual/libiconv )
+	systemd? ( sys-apps/systemd:= )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/tools/bootstrap
+	src/tools/moc
+	src/tools/rcc
+	src/tools/qfloat16-tables
+	src/corelib
+	src/tools/qlalr
+	doc
+)
+
+src_configure() {
+	local myconf=(
+		$(qt_use icu)
+		$(qt_use !icu iconv)
+		$(qt_use systemd journald)
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.9.9999.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.9.9999.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="3D data visualization library for the Qt5 framework"
+LICENSE="GPL-3"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+IUSE="gles2 qml"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	# eliminate bogus dependency on qtwidgets
+	sed -i -e '/requires.*widgets/d' qtdatavis3d.pro || die
+
+	qt_use_disable_mod qml quick \
+		src/src.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtdbus/qtdbus-5.9.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.9.9999.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Qt5 module for inter-process communication over the D-Bus protocol"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	>=sys-apps/dbus-1.4.20
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/corelib
+	src/dbus
+	src/tools/qdbusxml2cpp
+	src/tools/qdbuscpp2xml
+)
+
+QT5_GENTOO_CONFIG=(
+	:dbus
+	:dbus-linked:
+)
+
+src_prepare() {
+	qt5-build_src_prepare
+
+	cat > "${S}/src/corelib/corelib.pro" <<-_EOF_ || die
+		QT         =
+		TARGET     = QtCore
+		load(qt_module)
+	_EOF_
+}
+
+src_configure() {
+	local myconf=(
+		-dbus-linked
+	)
+	qt5-build_src_configure
+}
+
+src_compile() {
+	hack() {
+		emake
+		if [[ ${subdir} = "src/corelib" ]]; then
+			rm "${QT5_BUILD_DIR}"/lib/libQt5Core* || die
+		fi
+	}
+	qt5_foreach_target_subdir hack
+}
+
+src_install() {
+	QT5_TARGET_SUBDIRS=(
+		src/dbus
+		src/tools/qdbusxml2cpp
+		src/tools/qdbuscpp2xml
+	)
+	qt5-build_src_install
+}

--- a/dev-qt/qtdeclarative/qtdeclarative-5.9.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.9.9999.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 python3_{4,5} )
+inherit python-any-r1 qt5-build
+
+DESCRIPTION="The QML and Quick modules for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="gles2 +jit localstorage +widgets xml"
+
+# qtgui[gles2=] is needed because of bug 504322
+COMMON_DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qttest-${PV}
+	localstorage? ( ~dev-qt/qtsql-${PV} )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	xml? (
+		~dev-qt/qtnetwork-${PV}
+		~dev-qt/qtxmlpatterns-${PV}
+	)
+"
+DEPEND="${COMMON_DEPEND}
+	${PYTHON_DEPS}
+"
+RDEPEND="${COMMON_DEPEND}
+	!<dev-qt/qtquickcontrols-5.7:5
+"
+
+src_prepare() {
+	use jit || PATCHES+=("${FILESDIR}/${PN}-5.4.2-disable-jit.patch")
+
+	use localstorage || sed -i -e '/localstorage/d' \
+		src/imports/imports.pro || die
+
+	qt_use_disable_mod widgets widgets \
+		src/src.pro \
+		src/qmltest/qmltest.pro \
+		tests/auto/auto.pro \
+		tools/tools.pro \
+		tools/qmlscene/qmlscene.pro \
+		tools/qml/qml.pro
+
+	qt_use_disable_mod xml xmlpatterns \
+		src/imports/imports.pro \
+		tests/auto/quick/quick.pro \
+		tests/auto/quick/examples/examples.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtdiag/qtdiag-5.9.9999.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.9.9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Tool for reporting diagnostic information about Qt and its environment"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE="+ssl"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}[ssl=]
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qtdiag
+)

--- a/dev-qt/qtgraphicaleffects/qtgraphicaleffects-5.9.9999.ebuild
+++ b/dev-qt/qtgraphicaleffects/qtgraphicaleffects-5.9.9999.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+VIRTUALX_REQUIRED="test"
+inherit qt5-build
+
+DESCRIPTION="Set of QML types for adding visual effects to user interfaces"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgui-${PV}
+"
+DEPEND="${RDEPEND}"

--- a/dev-qt/qtgui/qtgui-5.9.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9.9999.ebuild
@@ -1,0 +1,164 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+# TODO: linuxfb
+
+IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus
+	jpeg libinput +png tslib tuio +udev vnc +xcb"
+REQUIRED_USE="
+	|| ( eglfs xcb )
+	accessibility? ( dbus xcb )
+	eglfs? ( egl )
+	ibus? ( dbus )
+	libinput? ( udev )
+	xcb? ( gles2? ( egl ) )
+"
+
+RDEPEND="
+	dev-libs/glib:2
+	~dev-qt/qtcore-${PV}
+	media-libs/fontconfig
+	>=media-libs/freetype-2.6.1:2
+	>=media-libs/harfbuzz-1.0.6:=
+	>=sys-libs/zlib-1.2.5
+	virtual/opengl
+	dbus? ( ~dev-qt/qtdbus-${PV} )
+	egl? ( media-libs/mesa[egl] )
+	eglfs? (
+		media-libs/mesa[gbm]
+		x11-libs/libdrm
+	)
+	evdev? ( sys-libs/mtdev )
+	gles2? ( media-libs/mesa[gles2] )
+	jpeg? ( virtual/jpeg:0 )
+	libinput? (
+		dev-libs/libinput:=
+		x11-libs/libxkbcommon
+	)
+	png? ( media-libs/libpng:0= )
+	tslib? ( x11-libs/tslib )
+	tuio? ( ~dev-qt/qtnetwork-${PV} )
+	udev? ( virtual/libudev:= )
+	vnc? ( ~dev-qt/qtnetwork-${PV} )
+	xcb? (
+		x11-libs/libICE
+		x11-libs/libSM
+		x11-libs/libX11
+		>=x11-libs/libXi-1.7.4
+		>=x11-libs/libxcb-1.10:=[xkb]
+		>=x11-libs/libxkbcommon-0.4.1[X]
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-renderutil
+		x11-libs/xcb-util-wm
+	)
+"
+DEPEND="${RDEPEND}
+	evdev? ( sys-kernel/linux-headers )
+	udev? ( sys-kernel/linux-headers )
+"
+PDEPEND="
+	ibus? ( app-i18n/ibus )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/gui
+	src/openglextensions
+	src/platformheaders
+	src/platformsupport
+	src/plugins/generic
+	src/plugins/imageformats
+	src/plugins/platforms
+	src/plugins/platforminputcontexts
+)
+
+QT5_GENTOO_CONFIG=(
+	accessibility:accessibility-atspi-bridge
+	egl
+	eglfs
+	eglfs:eglfs_egldevice:
+	eglfs:eglfs_gbm:
+	evdev
+	evdev:mtdev:
+	:fontconfig
+	:system-freetype:FREETYPE
+	!:no-freetype:
+	!gif:no-gif:
+	gles2::OPENGL_ES
+	gles2:opengles2:OPENGL_ES_2
+	!:no-gui:
+	:system-harfbuzz:HARFBUZZ
+	!:no-harfbuzz:
+	jpeg:system-jpeg:IMAGEFORMAT_JPEG
+	!jpeg:no-jpeg:
+	libinput
+	libinput:xkbcommon-evdev:
+	:opengl
+	png:png:
+	png:system-png:IMAGEFORMAT_PNG
+	!png:no-png:
+	tslib
+	udev:libudev:
+	xcb:xcb:
+	xcb:xcb-glx:
+	xcb:xcb-plugin:
+	xcb:xcb-render:
+	xcb:xcb-sm:
+	xcb:xcb-xlib:
+	xcb:xinput2:
+	xcb::XKB
+)
+
+src_prepare() {
+	# egl_x11 is activated when both egl and xcb are enabled
+	use egl && QT5_GENTOO_CONFIG+=(xcb:egl_x11) || QT5_GENTOO_CONFIG+=(egl:egl_x11)
+
+	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
+		src/platformsupport/platformsupport.pro || die
+
+	qt_use_disable_config tuio udpsocket src/plugins/generic/generic.pro
+
+	qt_use_disable_mod ibus dbus \
+		src/plugins/platforminputcontexts/platforminputcontexts.pro
+
+	use vnc || sed -i -e '/SUBDIRS += vnc/d' \
+		src/plugins/platforms/platforms.pro || die
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myconf=(
+		$(usex dbus -dbus-linked '')
+		$(qt_use egl)
+		$(qt_use eglfs)
+		$(usex eglfs '-gbm -kms' '')
+		$(qt_use evdev)
+		$(qt_use evdev mtdev)
+		-fontconfig
+		-system-freetype
+		$(usex gif '' -no-gif)
+		-system-harfbuzz
+		$(qt_use jpeg libjpeg system)
+		$(qt_use libinput)
+		$(qt_use libinput xkbcommon-evdev)
+		-opengl $(usex gles2 es2 desktop)
+		$(qt_use png libpng system)
+		$(qt_use tslib)
+		$(qt_use udev libudev)
+		$(qt_use xcb xcb system)
+		$(qt_use xcb xkbcommon-x11 system)
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qthelp/qthelp-5.9.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.9.9999.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Qt5 module for integrating online documentation into applications"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtsql-${PV}[sqlite]
+	~dev-qt/qtwidgets-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/assistant/clucene
+	src/assistant/help
+	src/assistant/qcollectiongenerator
+	src/assistant/qhelpconverter
+	src/assistant/qhelpgenerator
+)

--- a/dev-qt/qtimageformats/qtimageformats-5.9.9999.ebuild
+++ b/dev-qt/qtimageformats/qtimageformats-5.9.9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Additional format plugins for the Qt image I/O system"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	media-libs/jasper:=
+	media-libs/libmng:=
+	media-libs/libwebp:=
+	media-libs/tiff:0
+"
+RDEPEND="${DEPEND}"

--- a/dev-qt/qtlocation/qtlocation-5.9.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9.9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="The Location module for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtpositioning-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/3rdparty
+	src/location
+	src/imports/location
+	src/plugins/geoservices
+)

--- a/dev-qt/qtmultimedia/qtmultimedia-5.9.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.9.9999.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Multimedia (audio, video, radio, camera) library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="alsa gles2 gstreamer gstreamer010 openal pulseaudio qml widgets"
+REQUIRED_USE="?? ( gstreamer gstreamer010 )"
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtnetwork-${PV}
+	alsa? ( media-libs/alsa-lib )
+	gstreamer? (
+		dev-libs/glib:2
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-bad:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-bad:0.10
+		media-libs/gst-plugins-base:0.10
+	)
+	pulseaudio? ( media-sound/pulseaudio )
+	qml? (
+		~dev-qt/qtdeclarative-${PV}
+		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		openal? ( media-libs/openal )
+	)
+	widgets? (
+		~dev-qt/qtopengl-${PV}
+		~dev-qt/qtwidgets-${PV}[gles2=]
+	)
+"
+DEPEND="${RDEPEND}
+	gstreamer? ( x11-proto/videoproto )
+"
+
+src_prepare() {
+	# do not rely on qtbase configuration
+	sed -i -e 's/contains(QT_CONFIG, \(alsa\|pulseaudio\))://' \
+		qtmultimedia.pro || die
+
+	qt_use_compile_test alsa
+	qt_use_compile_test gstreamer
+	qt_use_compile_test openal
+	qt_use_compile_test pulseaudio
+
+	qt_use_disable_mod qml quick \
+		src/src.pro \
+		src/plugins/plugins.pro
+
+	qt_use_disable_mod widgets widgets \
+		src/src.pro \
+		src/gsttools/gsttools.pro \
+		src/plugins/gstreamer/common.pri
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myqmakeargs=(
+		$(usex gstreamer 'GST_VERSION=1.0' '')
+		$(usex gstreamer010 'GST_VERSION=0.10' '')
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtnetwork/qtnetwork-5.9.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.9.9999.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Network abstraction library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="bindist connman libproxy networkmanager +ssl"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	>=sys-libs/zlib-1.2.5
+	connman? ( ~dev-qt/qtdbus-${PV} )
+	libproxy? ( net-libs/libproxy )
+	networkmanager? ( ~dev-qt/qtdbus-${PV} )
+	ssl? ( dev-libs/openssl:0[bindist=] )
+"
+RDEPEND="${DEPEND}
+	connman? ( net-misc/connman )
+	networkmanager? ( net-misc/networkmanager )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/network
+	src/plugins/bearer/generic
+)
+
+QT5_GENTOO_CONFIG=(
+	libproxy
+	ssl::SSL
+	ssl::OPENSSL
+	ssl:openssl-linked:LINKED_OPENSSL
+)
+
+pkg_setup() {
+	use connman && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/connman)
+	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
+}
+
+src_configure() {
+	local myconf=(
+		$(use connman || use networkmanager && echo -dbus-linked)
+		$(qt_use libproxy)
+		$(usex ssl -openssl-linked '')
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtopengl/qtopengl-5.9.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.9.9999.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+VIRTUALX_REQUIRED="test"
+inherit qt5-build
+
+DESCRIPTION="OpenGL support library for the Qt5 framework (deprecated)"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="gles2"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtwidgets-${PV}[gles2=]
+	virtual/opengl
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/opengl
+)
+
+src_configure() {
+	local myconf=(
+		-opengl $(usex gles2 es2 desktop)
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtpaths/qtpaths-5.9.9999.ebuild
+++ b/dev-qt/qtpaths/qtpaths-5.9.9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Command line client to QStandardPaths"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qtpaths
+)

--- a/dev-qt/qtplugininfo/qtplugininfo-5.9.9999.ebuild
+++ b/dev-qt/qtplugininfo/qtplugininfo-5.9.9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qttools"
+inherit qt5-build
+
+DESCRIPTION="Qt5 plugin metadata dumper"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/qtplugininfo
+)

--- a/dev-qt/qtpositioning/qtpositioning-5.9.9999.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.9.9999.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtlocation"
+inherit qt5-build
+
+DESCRIPTION="Physical position determination library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE="geoclue qml"
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	geoclue? ( ~dev-qt/qtdbus-${PV} )
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+DEPEND="${RDEPEND}"
+PDEPEND="
+	geoclue? ( app-misc/geoclue:0 )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/positioning
+	src/plugins/position/positionpoll
+)
+
+pkg_setup() {
+	use geoclue && QT5_TARGET_SUBDIRS+=(src/plugins/position/geoclue)
+	use qml && QT5_TARGET_SUBDIRS+=(src/imports/positioning)
+}

--- a/dev-qt/qtprintsupport/qtprintsupport-5.9.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.9.9999.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+VIRTUALX_REQUIRED="test"
+inherit qt5-build
+
+DESCRIPTION="Printing support library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="cups gles2"
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtwidgets-${PV}[gles2=]
+	cups? ( >=net-print/cups-1.4 )
+"
+DEPEND="${RDEPEND}
+	test? ( ~dev-qt/qtnetwork-${PV} )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/printsupport
+	src/plugins/printsupport
+)
+
+QT5_GENTOO_CONFIG=(
+	cups
+)
+
+src_configure() {
+	local myconf=(
+		$(qt_use cups)
+		-opengl $(usex gles2 es2 desktop)
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtquickcontrols/qtquickcontrols-5.9.9999.ebuild
+++ b/dev-qt/qtquickcontrols/qtquickcontrols-5.9.9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Set of controls used in conjunction with Qt Quick to build complete interfaces"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="+widgets"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgui-${PV}
+	widgets? ( ~dev-qt/qtwidgets-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod widgets widgets \
+		src/src.pro \
+		src/controls/Private/private.pri \
+		tests/auto/activeFocusOnTab/activeFocusOnTab.pro \
+		tests/auto/controls/controls.pro \
+		tests/auto/testplugin/testplugin.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtquickcontrols2/qtquickcontrols2-5.9.9999.ebuild
+++ b/dev-qt/qtquickcontrols2/qtquickcontrols2-5.9.9999.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Set of next generation Qt Quick controls for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgraphicaleffects-${PV}
+	~dev-qt/qtgui-${PV}
+"
+RDEPEND="${DEPEND}"

--- a/dev-qt/qtscript/qtscript-5.9.9999.ebuild
+++ b/dev-qt/qtscript/qtscript-5.9.9999.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Application scripting library for the Qt5 framework (deprecated)"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="+jit scripttools"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	scripttools? (
+		~dev-qt/qtgui-${PV}
+		~dev-qt/qtwidgets-${PV}
+	)
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod scripttools widgets \
+		src/src.pro
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myqmakeargs=(
+		$(usex jit '' JAVASCRIPTCORE_JIT=no)
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtscxml/qtscxml-5.9.9999.ebuild
+++ b/dev-qt/qtscxml/qtscxml-5.9.9999.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="State Chart XML (SCXML) support library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+"
+RDEPEND="${DEPEND}"

--- a/dev-qt/qtsensors/qtsensors-5.9.9999.ebuild
+++ b/dev-qt/qtsensors/qtsensors-5.9.9999.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Hardware sensor access library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE="qml"
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod qml quick \
+		src/src.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtserialport/qtserialport-5.9.9999.ebuild
+++ b/dev-qt/qtserialport/qtserialport-5.9.9999.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Serial port abstraction library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	virtual/libudev:=
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	# make sure we link against libudev
+	sed -i -e 's/:contains(QT_CONFIG,\s*libudev)//' \
+		src/serialport/serialport-lib.pri || die
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtsql/qtsql-5.9.9999.ebuild
+++ b/dev-qt/qtsql/qtsql-5.9.9999.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="SQL abstraction library for the Qt5 tooolkit"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="freetds mysql oci8 odbc postgres +sqlite"
+
+REQUIRED_USE="
+	|| ( freetds mysql oci8 odbc postgres sqlite )
+"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	freetds? ( dev-db/freetds )
+	mysql? ( virtual/libmysqlclient:= )
+	oci8? ( dev-db/oracle-instantclient-basic )
+	odbc? ( || ( dev-db/unixODBC dev-db/libiodbc ) )
+	postgres? ( dev-db/postgresql:* )
+	sqlite? ( >=dev-db/sqlite-3.8.10.2:3 )
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/sql
+	src/plugins/sqldrivers
+)
+
+src_configure() {
+	local myconf=(
+		$(qt_use freetds  sql-tds    plugin)
+		$(qt_use mysql    sql-mysql  plugin)
+		$(qt_use oci8     sql-oci    plugin)
+		$(qt_use odbc     sql-odbc   plugin)
+		$(qt_use postgres sql-psql   plugin)
+		$(qt_use sqlite   sql-sqlite plugin)
+		$(usex sqlite -system-sqlite '')
+	)
+
+	use mysql && myconf+=("-I${EPREFIX}/usr/include/mysql" "-L${EPREFIX}/usr/$(get_libdir)/mysql")
+	use oci8 && myconf+=("-I${ORACLE_HOME}/include" "-L${ORACLE_HOME}/$(get_libdir)")
+	use odbc && myconf+=("-I${EPREFIX}/usr/include/iodbc")
+	use postgres && myconf+=("-I${EPREFIX}/usr/include/postgresql/pgsql")
+
+	qt5-build_src_configure
+}

--- a/dev-qt/qtsvg/qtsvg-5.9.9999.ebuild
+++ b/dev-qt/qtsvg/qtsvg-5.9.9999.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="SVG rendering library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtwidgets-${PV}
+	>=sys-libs/zlib-1.2.5
+"
+DEPEND="${RDEPEND}
+	test? ( ~dev-qt/qtxml-${PV} )
+"

--- a/dev-qt/qttest/qttest-5.9.9999.ebuild
+++ b/dev-qt/qttest/qttest-5.9.9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+VIRTUALX_REQUIRED="test"
+inherit qt5-build
+
+DESCRIPTION="Unit testing library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+"
+DEPEND="${RDEPEND}
+	test? (
+		~dev-qt/qtgui-${PV}
+		~dev-qt/qtxml-${PV}
+	)
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/testlib
+)

--- a/dev-qt/qttranslations/qttranslations-5.9.9999.ebuild
+++ b/dev-qt/qttranslations/qttranslations-5.9.9999.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Translation files for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/linguist-tools-${PV}
+	~dev-qt/qtcore-${PV}
+"
+RDEPEND=""

--- a/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Wayland platform plugin for Qt"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE="egl xcomposite"
+
+DEPEND="
+	>=dev-libs/wayland-1.4.0
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgui-${PV}[egl=]
+	media-libs/mesa[egl?]
+	>=x11-libs/libxkbcommon-0.2.0
+	xcomposite? (
+		x11-libs/libX11
+		x11-libs/libXcomposite
+	)
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	qt_use_compile_test xcomposite
+
+	qt5-build_src_configure
+}

--- a/dev-qt/qtwebchannel/qtwebchannel-5.9.9999.ebuild
+++ b/dev-qt/qtwebchannel/qtwebchannel-5.9.9999.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Qt5 module for integrating C++ and QML applications with HTML/JavaScript clients"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~ppc64 ~x86"
+fi
+
+IUSE="qml"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod qml quick src/src.pro
+	qt_use_disable_mod qml qml src/webchannel/webchannel.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -1,0 +1,111 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+inherit pax-utils python-any-r1 qt5-build
+
+DESCRIPTION="Library for rendering dynamic web content in Qt5 C++ and QML applications"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~x86"
+fi
+
+IUSE="bindist geolocation pax_kernel +system-ffmpeg +system-icu widgets"
+
+RDEPEND="
+	app-arch/snappy
+	dev-libs/glib:2
+	dev-libs/nspr
+	dev-libs/nss
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtdeclarative-${PV}
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtwebchannel-${PV}[qml]
+	dev-libs/expat
+	dev-libs/jsoncpp:=
+	dev-libs/libevent:=
+	dev-libs/libxml2
+	dev-libs/libxslt
+	dev-libs/protobuf:=
+	media-libs/alsa-lib
+	media-libs/flac
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/harfbuzz:=
+	media-libs/libpng:0=
+	>=media-libs/libvpx-1.5:=[svc]
+	media-libs/libwebp:=
+	media-libs/mesa
+	media-libs/opus
+	media-libs/speex
+	net-libs/libsrtp:0=
+	sys-apps/dbus
+	sys-apps/pciutils
+	sys-libs/libcap
+	sys-libs/zlib[minizip]
+	x11-libs/libdrm
+	x11-libs/libX11
+	x11-libs/libXcomposite
+	x11-libs/libXcursor
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXi
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	x11-libs/libXScrnSaver
+	x11-libs/libXtst
+	geolocation? ( ~dev-qt/qtpositioning-${PV} )
+	system-ffmpeg? ( media-video/ffmpeg:0= )
+	system-icu? ( dev-libs/icu:= )
+	widgets? ( ~dev-qt/qtwidgets-${PV} )
+"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	dev-util/gperf
+	dev-util/ninja
+	dev-util/re2c
+	sys-devel/bison
+	pax_kernel? ( sys-apps/elfix )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.7.0-fix-system-ffmpeg.patch"
+	"${FILESDIR}/${PN}-5.7.0-icu58.patch"
+)
+
+src_prepare() {
+	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
+
+	if use system-icu; then
+		# ensure build against system headers - bug #601264
+		rm -r src/3rdparty/chromium/third_party/icu/source || die
+	fi
+
+	qt_use_disable_mod geolocation positioning \
+		src/core/core_common.pri \
+		src/core/core_gyp_generator.pro
+
+	qt_use_disable_mod widgets widgets src/src.pro
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	export NINJA_PATH=/usr/bin/ninja
+
+	local myqmakeargs=(
+		$(usex bindist '' 'WEBENGINE_CONFIG+=use_proprietary_codecs')
+		$(usex system-ffmpeg 'WEBENGINE_CONFIG+=use_system_ffmpeg' '')
+		$(usex system-icu 'WEBENGINE_CONFIG+=use_system_icu' '')
+	)
+	qt5-build_src_configure
+}
+
+src_install() {
+	qt5-build_src_install
+
+	pax-mark m "${D%/}${QT5_LIBEXECDIR}"/QtWebEngineProcess
+}

--- a/dev-qt/qtwebkit/qtwebkit-5.9.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9.9999.ebuild
@@ -1,0 +1,107 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 )
+inherit python-any-r1 qt5-build
+
+DESCRIPTION="WebKit rendering library for the Qt5 framework (deprecated)"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+fi
+
+# TODO: qttestlib
+
+IUSE="geolocation gstreamer gstreamer010 +jit multimedia opengl orientation printsupport qml webchannel webp"
+REQUIRED_USE="?? ( gstreamer gstreamer010 multimedia )"
+
+RDEPEND="
+	dev-db/sqlite:3
+	dev-libs/icu:=
+	>=dev-libs/leveldb-1.18-r1
+	dev-libs/libxml2:2
+	dev-libs/libxslt
+	~dev-qt/qtcore-${PV}[icu]
+	~dev-qt/qtgui-${PV}
+	~dev-qt/qtnetwork-${PV}
+	~dev-qt/qtsql-${PV}
+	~dev-qt/qtwidgets-${PV}
+	media-libs/fontconfig:1.0
+	media-libs/libpng:0=
+	>=sys-libs/zlib-1.2.5
+	virtual/jpeg:0
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXcomposite
+	x11-libs/libXrender
+	geolocation? ( ~dev-qt/qtpositioning-${PV} )
+	gstreamer? (
+		dev-libs/glib:2
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+	)
+	gstreamer010? (
+		dev-libs/glib:2
+		media-libs/gstreamer:0.10
+		media-libs/gst-plugins-base:0.10
+	)
+	multimedia? ( ~dev-qt/qtmultimedia-${PV}[widgets] )
+	opengl? ( ~dev-qt/qtopengl-${PV} )
+	orientation? ( ~dev-qt/qtsensors-${PV} )
+	printsupport? ( ~dev-qt/qtprintsupport-${PV} )
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+	webchannel? ( ~dev-qt/qtwebchannel-${PV} )
+	webp? ( media-libs/libwebp:0= )
+"
+DEPEND="${RDEPEND}
+	${PYTHON_DEPS}
+	dev-lang/ruby
+	dev-util/gperf
+	sys-devel/bison
+	sys-devel/flex
+	virtual/rubygems
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.4.2-system-leveldb.patch"
+)
+
+src_prepare() {
+	# ensure bundled library cannot be used
+	rm -r Source/ThirdParty/leveldb || die
+
+	# bug 466216
+	sed -i -e '/CONFIG +=/s/rpath//' \
+		Source/WebKit/qt/declarative/{experimental/experimental,public}.pri \
+		Tools/qmake/mkspecs/features/{force_static_libs_as_shared,unix/default_post}.prf \
+		|| die
+
+	qt_use_disable_mod geolocation positioning Tools/qmake/mkspecs/features/features.prf
+	qt_use_disable_mod multimedia multimediawidgets Tools/qmake/mkspecs/features/features.prf
+	qt_use_disable_mod orientation sensors Tools/qmake/mkspecs/features/features.prf
+	qt_use_disable_mod printsupport printsupport Tools/qmake/mkspecs/features/features.prf
+	qt_use_disable_mod qml quick Tools/qmake/mkspecs/features/features.prf
+	qt_use_disable_mod webchannel webchannel \
+		Source/WebKit2/Target.pri \
+		Source/WebKit2/WebKit2.pri
+
+	if use gstreamer010; then
+		PATCHES+=("${FILESDIR}/${PN}-5.8.0-use-gstreamer010.patch")
+	elif ! use gstreamer; then
+		PATCHES+=("${FILESDIR}/${PN}-5.8.0-disable-gstreamer.patch")
+	fi
+
+	# bug 562396
+	use jit || PATCHES+=("${FILESDIR}/${PN}-5.5.1-disable-jit.patch")
+
+	use opengl || sed -i -e '/contains(QT_CONFIG, opengl): WEBKIT_CONFIG += use_3d_graphics/d' \
+		Tools/qmake/mkspecs/features/features.prf || die
+	use webp || sed -i -e '/config_libwebp: WEBKIT_CONFIG += use_webp/d' \
+		Tools/qmake/mkspecs/features/features.prf || die
+
+	# bug 458222
+	sed -i -e '/SUBDIRS += examples/d' Source/QtWebKit.pro || die
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtwebsockets/qtwebsockets-5.9.9999.ebuild
+++ b/dev-qt/qtwebsockets/qtwebsockets-5.9.9999.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Implementation of the WebSocket protocol for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~x86"
+fi
+
+IUSE="qml +ssl"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtnetwork-${PV}[ssl=]
+	qml? ( ~dev-qt/qtdeclarative-${PV} )
+
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	qt_use_disable_mod qml quick src/src.pro
+
+	qt5-build_src_prepare
+}

--- a/dev-qt/qtwidgets/qtwidgets-5.9.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9.9999.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Set of components for creating classic desktop-style UIs for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+# keep IUSE defaults in sync with qtgui
+IUSE="gles2 gtk +png +xcb"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[gles2=,png=,xcb?]
+	gtk? (
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/pango
+	)
+"
+RDEPEND="${DEPEND}"
+
+QT5_TARGET_SUBDIRS=(
+	src/tools/uic
+	src/widgets
+	src/plugins/platformthemes
+)
+
+QT5_GENTOO_CONFIG=(
+	gtk:gtk3:
+	!:no-widgets:
+)
+
+src_configure() {
+	local myconf=(
+		-opengl $(usex gles2 es2 desktop)
+		$(qt_use gtk)
+		$(qt_use png libpng system)
+		$(qt_use xcb xcb system)
+		$(qt_use xcb xkbcommon system)
+		$(usex xcb '-xcb-xlib -xinput2 -xkb' '')
+	)
+	qt5-build_src_configure
+}

--- a/dev-qt/qtx11extras/qtx11extras-5.9.9999.ebuild
+++ b/dev-qt/qtx11extras/qtx11extras-5.9.9999.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="Linux/X11-specific support library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtgui-${PV}[xcb]
+"
+DEPEND="${RDEPEND}
+	test? ( ~dev-qt/qtwidgets-${PV} )
+"

--- a/dev-qt/qtxml/qtxml-5.9.9999.ebuild
+++ b/dev-qt/qtxml/qtxml-5.9.9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Implementation of SAX and DOM for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+RDEPEND="
+	~dev-qt/qtcore-${PV}
+"
+DEPEND="${RDEPEND}
+	test? ( ~dev-qt/qtnetwork-${PV} )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/xml
+)

--- a/dev-qt/qtxmlpatterns/qtxmlpatterns-5.9.9999.ebuild
+++ b/dev-qt/qtxmlpatterns/qtxmlpatterns-5.9.9999.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qt5-build
+
+DESCRIPTION="XPath, XQuery, XSLT, and XML Schema validation library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+fi
+
+IUSE=""
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	~dev-qt/qtnetwork-${PV}
+"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
Tested only building the packages required for QupZilla, using only one combination of USE-flags.

Copied/renamed the most current '5.9999' ebuilds, with some minor tweaks.

For 'qtcore':

- Added 'src/tools/qfloat16-tables' to 'QT5_TARGET_SUBDIRS'.
- Changed dependency from '>=dev-libs/libpcre-8.38[pcre16,unicode]' to 'dev-libs/libpcre2[pcre16,unicode]'.

For 'qtwebengine':

- Removed patches.
- Changed 'src/core/core_gyp_generator.pro' to 'src/core/core_generator.pro'.
- Removed the removal of 'src/3rdparty/chromium/third_party/icu/source'.  Have not yet really tested if the system-icu was indeed used (config did say it was).  I saw one particular commit that may or may not have something to do with this: http://code.qt.io/cgit/qt/qtwebengine.git/commit/?h=5.9&id=16d8518e58fcaf6495604ae2d9188cc59b3e661b
- Reverted http://code.qt.io/cgit/qt/qtwebengine.git/commit/?h=5.9&id=f6c1a34972eb2d9132346ab4eb442855d3ef555e since for a reason or another, the check fails to detect 'icuuc' even though it is there.

With regards to 'qtwebengine', I left only the removal of patches, and renaming of 'src/core/core_gyp_generator.pro' to 'src/core/core_generator.pro' in for this push, as it will probably be better to fix the other things in separate commits, and more proper-like.

Colour me surprised if I didn't forget anything.