### PR TITLE
dev-qt/qtcore: Adjust 'libpcre' dep and add a subdir.

### DIFF
--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -16,7 +16,7 @@ IUSE="icu systemd"
 DEPEND="
 	dev-libs/double-conversion:=
 	dev-libs/glib:2
-	>=dev-libs/libpcre-8.38[pcre16,unicode]
+	dev-libs/libpcre2[pcre16,unicode]
 	>=sys-libs/zlib-1.2.5
 	icu? ( dev-libs/icu:= )
 	!icu? ( virtual/libiconv )

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -28,6 +28,7 @@ QT5_TARGET_SUBDIRS=(
 	src/tools/bootstrap
 	src/tools/moc
 	src/tools/rcc
+	src/tools/qfloat16-tables
 	src/corelib
 	src/tools/qlalr
 	doc


### PR DESCRIPTION
Configuring will now fail without 'dev-libs/libpcre2[pcre16]' and the new 'src/tools/qfloat16-tables' subdir needs to be processed before 'src/corelib'.