### PR TITLE
Qt >= 5.8: Build fixes

### DIFF
--- a/dev-qt/qtdbus/qtdbus-5.8.0.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.8.0.ebuild
@@ -20,7 +20,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/corelib
 	src/dbus
 	src/tools/qdbusxml2cpp
 	src/tools/qdbuscpp2xml
@@ -31,38 +30,9 @@ QT5_GENTOO_CONFIG=(
 	:dbus-linked:
 )
 
-src_prepare() {
-	qt5-build_src_prepare
-
-	cat > "${S}/src/corelib/corelib.pro" <<-_EOF_ || die
-		QT         =
-		TARGET     = QtCore
-		load(qt_module)
-	_EOF_
-}
-
 src_configure() {
 	local myconf=(
 		-dbus-linked
 	)
 	qt5-build_src_configure
-}
-
-src_compile() {
-	hack() {
-		emake
-		if [[ ${subdir} = "src/corelib" ]]; then
-			rm "${S}"/lib/libQt5Core* || die
-		fi
-	}
-	qt5_foreach_target_subdir hack
-}
-
-src_install() {
-	QT5_TARGET_SUBDIRS=(
-		src/dbus
-		src/tools/qdbusxml2cpp
-		src/tools/qdbuscpp2xml
-	)
-	qt5-build_src_install
 }

--- a/dev-qt/qtdbus/qtdbus-5.8.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.8.9999.ebuild
@@ -20,7 +20,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/corelib
 	src/dbus
 	src/tools/qdbusxml2cpp
 	src/tools/qdbuscpp2xml
@@ -31,38 +30,9 @@ QT5_GENTOO_CONFIG=(
 	:dbus-linked:
 )
 
-src_prepare() {
-	qt5-build_src_prepare
-
-	cat > "${S}/src/corelib/corelib.pro" <<-_EOF_ || die
-		QT         =
-		TARGET     = QtCore
-		load(qt_module)
-	_EOF_
-}
-
 src_configure() {
 	local myconf=(
 		-dbus-linked
 	)
 	qt5-build_src_configure
-}
-
-src_compile() {
-	hack() {
-		emake
-		if [[ ${subdir} = "src/corelib" ]]; then
-			rm "${QT5_BUILD_DIR}"/lib/libQt5Core* || die
-		fi
-	}
-	qt5_foreach_target_subdir hack
-}
-
-src_install() {
-	QT5_TARGET_SUBDIRS=(
-		src/dbus
-		src/tools/qdbusxml2cpp
-		src/tools/qdbuscpp2xml
-	)
-	qt5-build_src_install
 }

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -630,7 +630,10 @@ qt5_base_configure() {
 		$([[ ${QT5_MINOR_VERSION} -lt 8 ]] && echo -iconv)
 
 		# disable everything to prevent automagic deps (part 3)
-		-no-cups -no-evdev -no-tslib -no-icu -no-fontconfig -no-dbus
+		-no-cups -no-evdev -no-tslib -no-icu -no-fontconfig
+		# since 5.8, disabling dbus will issue a QT_NO_DBUS in QtCore/qconfig.h,
+		# thus specify runtime loading of libdbus to avoid deps and macro
+		$([[ ${QT5_MINOR_VERSION} -ge 8 ]] && echo -dbus-runtime || echo -no-dbus)
 
 		# let portage handle stripping
 		-no-strip


### PR DESCRIPTION
The commit msgs should be rather self-explanatory, I hope.

Generally it fixes the compilation of qtdbus and qtgui (+dbus) for Qt >= 5.8 as well as other packages that depend on qtdbus. I used 5.8 git head for my tests and recompiled kde-frameworks/* ... everything works just fine on my machine and I could not find any negative side-effects.