### PR TITLE
dev-qt/qtwebengine: Fix configure for the live 5.9 ebuilds.

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -86,7 +86,8 @@ src_prepare() {
 
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
-		src/core/core_gyp_generator.pro
+		src/core/core_chromium.pri \
+		tools/qmake/mkspecs/features/configure.prf
 
 	qt_use_disable_mod widgets widgets src/src.pro
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -71,11 +71,6 @@ DEPEND="${RDEPEND}
 	pax_kernel? ( sys-apps/elfix )
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-5.7.0-fix-system-ffmpeg.patch"
-	"${FILESDIR}/${PN}-5.7.0-icu58.patch"
-)
-
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -86,7 +86,8 @@ src_prepare() {
 
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
-		src/core/core_gyp_generator.pro
+		src/core/core_chromium.pri \
+		tools/qmake/mkspecs/features/configure.prf
 
 	qt_use_disable_mod widgets widgets src/src.pro
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -71,11 +71,6 @@ DEPEND="${RDEPEND}
 	pax_kernel? ( sys-apps/elfix )
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-5.7.0-fix-system-ffmpeg.patch"
-	"${FILESDIR}/${PN}-5.7.0-icu58.patch"
-)
-
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
 


### PR DESCRIPTION
This renames 'src/core/core_gyp_generator.pro' to 'src/core/core_generator.pro', and removes the unneeded/not applying patches from being used.