### PR TITLE
dev-qt/qtgui: Fix building 5.9 with 'dbus' disabled.

### DIFF
--- a/dev-qt/qtgui/qtgui-5.9.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9.9999.ebuild
@@ -123,10 +123,14 @@ src_prepare() {
 	# egl_x11 is activated when both egl and xcb are enabled
 	use egl && QT5_GENTOO_CONFIG+=(xcb:egl_x11) || QT5_GENTOO_CONFIG+=(egl:egl_x11)
 
-	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
-		src/platformsupport/platformsupport.pro || die
+	use dbus || sed -i -e '1 i\DEFINES += QT_NO_DBUS' \
+		src/platformsupport/themes/themes.pro || die
 
 	qt_use_disable_config tuio udpsocket src/plugins/generic/generic.pro
+
+	qt_use_disable_config dbus dbus \
+		src/src.pro \
+		src/platformsupport/themes/genericunix/genericunix.pri
 
 	qt_use_disable_mod ibus dbus \
 		src/plugins/platforminputcontexts/platforminputcontexts.pro
@@ -139,7 +143,7 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		$(usex dbus -dbus-linked '')
+		$(usex dbus -dbus-linked '-no-dbus')
 		$(qt_use egl)
 		$(qt_use eglfs)
 		$(usex eglfs '-gbm -kms' '')

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -123,10 +123,14 @@ src_prepare() {
 	# egl_x11 is activated when both egl and xcb are enabled
 	use egl && QT5_GENTOO_CONFIG+=(xcb:egl_x11) || QT5_GENTOO_CONFIG+=(egl:egl_x11)
 
-	use dbus || sed -i -e 's/contains(QT_CONFIG, dbus)/false/' \
-		src/platformsupport/platformsupport.pro || die
+	use dbus || sed -i -e '1 i\DEFINES += QT_NO_DBUS' \
+		src/platformsupport/themes/themes.pro || die
 
 	qt_use_disable_config tuio udpsocket src/plugins/generic/generic.pro
+
+	qt_use_disable_config dbus dbus \
+		src/src.pro \
+		src/platformsupport/themes/genericunix/genericunix.pri
 
 	qt_use_disable_mod ibus dbus \
 		src/plugins/platforminputcontexts/platforminputcontexts.pro
@@ -139,7 +143,7 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		$(usex dbus -dbus-linked '')
+		$(usex dbus -dbus-linked '-no-dbus')
 		$(qt_use egl)
 		$(qt_use eglfs)
 		$(usex eglfs '-gbm -kms' '')


### PR DESCRIPTION
The changes here are almost definitely no good as they are, but they at least show one idea of how to get 'qtgui[-dbus]' to build.

Without any changes, the compilation will fail due to 'unknown module in QT: dbus' or so.  Adding '-no-dbus' helps, but then it's looking for 'qdbusplatformmenu_p.h' (or so) because 'QT_NO_DBUS' is not defined for whatever reason, and defining it in 'src/platformsupport/themes/themes.pro' helps with that.

This is enough to make the compile a success, though I can still see something that looks like automagic picking up of 'qtdbus' if it is installed, when building other targets.

Similarly to earlier commits, the file(s) 'qt_use_disable_config' was working on has/have been changed, but I'm not sure it's of much (if any) help.

Some upstream changes that I believe are related to that in particular:

- http://code.qt.io/cgit/qt/qtbase.git/diff/?h=5.9&id=60985aa42b37217fb4c01ed85bbf6f14410c3491
- http://code.qt.io/cgit/qt/qtbase.git/diff/?h=5.9&id=13e7c603d51f22763d47e98a4e37468e46deac98
