### PR TITLE
qthelp: remove clucene subdir target

### DIFF
--- a/dev-qt/qthelp/qthelp-5.9.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.9.9999.ebuild
@@ -23,7 +23,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/assistant/clucene
 	src/assistant/help
 	src/assistant/qcollectiongenerator
 	src/assistant/qhelpconverter

--- a/dev-qt/qthelp/qthelp-5.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.9999.ebuild
@@ -23,7 +23,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/assistant/clucene
 	src/assistant/help
 	src/assistant/qcollectiongenerator
 	src/assistant/qhelpconverter


### PR DESCRIPTION
Please see the bug 617222.

https://bugs.gentoo.org/show_bug.cgi?id=617222