### PR TITLE
dev-qt/qtwebengine: Fix two configure/compile failures.

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.9.0_beta3.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.0_beta3.ebuild
@@ -74,11 +74,6 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
 
-	if use system-icu; then
-		# ensure build against system headers - bug #601264
-		rm -r src/3rdparty/chromium/third_party/icu/source || die
-	fi
-
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
 		src/core/core_chromium.pri \

--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -74,11 +74,6 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
 
-	if use system-icu; then
-		# ensure build against system headers - bug #601264
-		rm -r src/3rdparty/chromium/third_party/icu/source || die
-	fi
-
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
 		src/core/core_chromium.pri \

--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -77,7 +77,7 @@ src_prepare() {
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
 		src/core/core_chromium.pri \
-		tools/qmake/mkspecs/features/configure.prf
+		mkspecs/features/configure.prf
 
 	qt_use_disable_mod widgets widgets src/src.pro
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -74,11 +74,6 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-paxmark-mksnapshot.patch" )
 
-	if use system-icu; then
-		# ensure build against system headers - bug #601264
-		rm -r src/3rdparty/chromium/third_party/icu/source || die
-	fi
-
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
 		src/core/core_chromium.pri \

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -77,7 +77,7 @@ src_prepare() {
 	qt_use_disable_mod geolocation positioning \
 		src/core/core_common.pri \
 		src/core/core_chromium.pri \
-		tools/qmake/mkspecs/features/configure.prf
+		mkspecs/features/configure.prf
 
 	qt_use_disable_mod widgets widgets src/src.pro
 


### PR DESCRIPTION
Compilation fails without the bundled ICU sources, because according to upstream, they also have the build scripts for using system ICU, and it does a weird thing of shadowing the system headers over the bundled ones, so they have to be there.

Furthermore, the qmake files have been moved around, and the 'tools/qmake' directory doesn't exist any longer, so 'configure.prf' can't be found (not yet in beta3).
