### PR TITLE
dev-qt/qtlocation: Fix build for 5.9.0+

### DIFF
--- a/dev-qt/qtlocation/qtlocation-5.9.0.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9.0.ebuild
@@ -22,7 +22,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/3rdparty
+	src/3rdparty/clipper
+	src/3rdparty/poly2tri
+	src/3rdparty/clip2tri
+	src/3rdparty/mapbox-gl-native
 	src/location
 	src/imports/location
 	src/plugins/geoservices

--- a/dev-qt/qtlocation/qtlocation-5.9.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9.9999.ebuild
@@ -22,7 +22,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/3rdparty
+	src/3rdparty/clipper
+	src/3rdparty/poly2tri
+	src/3rdparty/clip2tri
+	src/3rdparty/mapbox-gl-native
 	src/location
 	src/imports/location
 	src/plugins/geoservices

--- a/dev-qt/qtlocation/qtlocation-5.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9999.ebuild
@@ -22,7 +22,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
-	src/3rdparty
+	src/3rdparty/clipper
+	src/3rdparty/poly2tri
+	src/3rdparty/clip2tri
+	src/3rdparty/mapbox-gl-native
 	src/location
 	src/imports/location
 	src/plugins/geoservices


### PR DESCRIPTION
Because upstream has removed the top-level ``3rdparty.pro`` file (upstream commit qt/qtlocation@c54ee74acdb9757989004005baf79e99be4c9417 which is present in all 5.9.x including betas), we have to adapt and pick and choose the individual components now.

Tested with 5.9.9999.