### PR TITLE
Upstream Merged PySide2 and shiboken2, Now We Pick Up the Pieces

### DIFF
--- a/dev-python/pyside/pyside-9999.ebuild
+++ b/dev-python/pyside/pyside-9999.ebuild
@@ -10,8 +10,8 @@ inherit cmake-utils python-r1 virtualx git-r3
 DESCRIPTION="Python bindings for the Qt framework"
 HOMEPAGE="https://wiki.qt.io/PySide2"
 EGIT_REPO_URI=(
-	"git://code.qt.io/pyside/${PN}.git"
-	"https://code.qt.io/git/pyside/${PN}.git"
+	"git://code.qt.io/pyside/pyside-setup.git"
+	"https://code.qt.io/git/pyside/pyside-setup.git"
 )
 #FIXME: Switch to the clang-enabled "dev" branch once stable.
 EGIT_BRANCH="5.6"
@@ -77,15 +77,9 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-src_prepare() {
-	#FIXME: Remove the following "sed" patch after this upstream issue is closed:
-	#    https://bugreports.qt.io/browse/PYSIDE-502
-	# Force the optional "Qt5Concurrent", "Qt5Gui", "Qt5Network",
-	# "Qt5PrintSupport", "Qt5Sql", "Qt5Test", and "Qt5Widgets" packages
-	# erroneously marked as mandatory to be optional.
-	sed -i -e 's/^\(CHECK_PACKAGE_FOUND(Qt5\(Concurrent\|Gui\|Network\|PrintSupport\|Sql\|Test\|Widgets\)\))$/\1 opt)/' \
-		PySide2/CMakeLists.txt || die
+S="${WORKDIR}/${P}/sources/pyside2"
 
+src_prepare() {
 	if use prefix; then
 		cp "${FILESDIR}"/rpath.cmake . || die
 		sed -i -e '1iinclude(rpath.cmake)' CMakeLists.txt || die
@@ -95,10 +89,10 @@ src_prepare() {
 }
 
 src_configure() {
-	# For each line of the form "CHECK_PACKAGE_FOUND(${PACKAGE_NAME} opt)" in
-	# PySide2/CMakeLists.txt defining an optional dependency, an option of the
-	# form "-DCMAKE_DISABLE_FIND_PACKAGE_${PACKAGE_NAME}=$(usex !${USE_FLAG})"
-	# is passed to cmake here conditionally disabling this dependency.
+	# For each line in "${S}/CMakeLists.txt" of the form
+	# "COLLECT_MODULE_IF_FOUND(${PACKAGE_NAME} (opt|essential))" defining an
+	# optional dependency, pass "cmake" a command-line option of the form
+	# "-DCMAKE_DISABLE_FIND_PACKAGE_${PACKAGE_NAME}=$(usex !${USE_FLAG})".
 	local mycmakeargs=(
 		-DBUILD_TESTS=$(usex test)
 		-DCMAKE_DISABLE_FIND_PACKAGE_Qt5Concurrent=$(usex !concurrent)

--- a/dev-python/shiboken/shiboken-9999.ebuild
+++ b/dev-python/shiboken/shiboken-9999.ebuild
@@ -10,8 +10,8 @@ inherit cmake-utils llvm python-r1 git-r3
 DESCRIPTION="Tool for creating Python bindings for C++ libraries"
 HOMEPAGE="https://wiki.qt.io/PySide2"
 EGIT_REPO_URI=(
-	"git://code.qt.io/pyside/${PN}.git"
-	"https://code.qt.io/git/pyside/${PN}.git"
+	"git://code.qt.io/pyside/pyside-setup.git"
+	"https://code.qt.io/git/pyside/pyside-setup.git"
 )
 #FIXME: Switch to the clang-enabled "dev" branch once stable.
 EGIT_BRANCH="5.6"
@@ -35,6 +35,8 @@ DEPEND="
 	=dev-qt/qtxmlpatterns-${QT_PV}
 "
 RDEPEND="${DEPEND}"
+
+S="${WORKDIR}/${P}/sources/shiboken2"
 
 DOCS=( AUTHORS )
 


### PR DESCRIPTION
Greetings, @Pesa and crew.

This pull request retargets the PySide2 and shiboken2 ebuilds to pull from the recently refactored [pyside-setup.git](http://code.qt.io/cgit/pyside/pyside-setup.git) repository, which merges the contents of the now unmaintained [pyside.git](http://code.qt.io/cgit/pyside/pyside.git) and [shiboken.git](http://code.qt.io/cgit/pyside/shiboken.git) repositories. To quote [upstream developer notes](https://wiki.qt.io/PySide2#Pyside_Development_Progress_Notes):

> 18. May 2017
> -> merge will happen in the next few days (pyside.git, pyside-setup.git and shiboken.git become one repo)
> -> examples, wiki and tools will remain as they are

> 1. June 2017
> - pyside repo merge completed

Personally, this merger strikes me as a terrible idea. PySide2 and shiboken2 are fundamentally different projects. Nokia correctly separated them for a reason. The Qt Company feels differently, however. There's little we can do about that... except complain like I am currently doing.

Relatedly, upstream has resolved [PYSIDE-502](https://bugreports.qt.io/browse/PYSIDE-502). All optional PySide2 dependencies are now explicitly listed as such by `sources/pyside2/CMakeLists.txt`. The corresponding hack in our PySide2 ebuild that forced this to be the case has been removed. All were rejoiced.

That's about it. Thanks for the ongoing Qt dedication. Have my precious thumbs. 👍👍 