### PR TITLE
make QT_PV reflect minimal QT version to allow use of QT5.6+

### DIFF
--- a/dev-python/pyside/pyside-9999.ebuild
+++ b/dev-python/pyside/pyside-9999.ebuild
@@ -47,33 +47,33 @@ REQUIRED_USE="
 
 # Minimum version of Qt required, derived from the CMakeLists.txt line:
 #   find_package(Qt5 ${QT_PV} REQUIRED COMPONENTS Core)
-QT_PV="5.6*:5"
+QT_PV="5.6:5"
 
 DEPEND="
 	${PYTHON_DEPS}
 	>=dev-python/shiboken-${PV}:${SLOT}[${PYTHON_USEDEP}]
-	=dev-qt/qtcore-${QT_PV}
-	=dev-qt/qtxml-${QT_PV}
-	concurrent? ( =dev-qt/qtconcurrent-${QT_PV} )
-	declarative? ( =dev-qt/qtdeclarative-${QT_PV}[widgets?] )
-	designer? ( =dev-qt/designer-${QT_PV} )
-	gui? ( =dev-qt/qtgui-${QT_PV} )
-	help? ( =dev-qt/qthelp-${QT_PV} )
-	multimedia? ( =dev-qt/qtmultimedia-${QT_PV}[widgets?] )
-	network? ( =dev-qt/qtnetwork-${QT_PV} )
-	opengl? ( =dev-qt/qtopengl-${QT_PV} )
-	printsupport? ( =dev-qt/qtprintsupport-${QT_PV} )
-	script? ( =dev-qt/qtscript-${QT_PV} )
-	sql? ( =dev-qt/qtsql-${QT_PV} )
-	svg? ( =dev-qt/qtsvg-${QT_PV} )
-	testlib? ( =dev-qt/qttest-${QT_PV} )
-	webchannel? ( =dev-qt/qtwebchannel-${QT_PV} )
-	webengine? ( =dev-qt/qtwebengine-${QT_PV}[widgets] )
-	webkit? ( =dev-qt/qtwebkit-${QT_PV}[printsupport] )
-	websockets? ( =dev-qt/qtwebsockets-${QT_PV} )
-	widgets? ( =dev-qt/qtwidgets-${QT_PV} )
-	x11extras? ( =dev-qt/qtx11extras-${QT_PV} )
-	xmlpatterns? ( =dev-qt/qtxmlpatterns-${QT_PV} )
+	>=dev-qt/qtcore-${QT_PV}
+	>=dev-qt/qtxml-${QT_PV}
+	concurrent? ( >=dev-qt/qtconcurrent-${QT_PV} )
+	declarative? ( >=dev-qt/qtdeclarative-${QT_PV}[widgets?] )
+	designer? ( >=dev-qt/designer-${QT_PV} )
+	gui? ( >=dev-qt/qtgui-${QT_PV} )
+	help? ( >=dev-qt/qthelp-${QT_PV} )
+	multimedia? ( >=dev-qt/qtmultimedia-${QT_PV}[widgets?] )
+	network? ( >=dev-qt/qtnetwork-${QT_PV} )
+	opengl? ( >=dev-qt/qtopengl-${QT_PV} )
+	printsupport? ( >=dev-qt/qtprintsupport-${QT_PV} )
+	script? ( >=dev-qt/qtscript-${QT_PV} )
+	sql? ( >=dev-qt/qtsql-${QT_PV} )
+	svg? ( >=dev-qt/qtsvg-${QT_PV} )
+	testlib? ( >=dev-qt/qttest-${QT_PV} )
+	webchannel? ( >=dev-qt/qtwebchannel-${QT_PV} )
+	webengine? ( >=dev-qt/qtwebengine-${QT_PV}[widgets] )
+	webkit? ( >=dev-qt/qtwebkit-${QT_PV}[printsupport] )
+	websockets? ( >=dev-qt/qtwebsockets-${QT_PV} )
+	widgets? ( >=dev-qt/qtwidgets-${QT_PV} )
+	x11extras? ( >=dev-qt/qtx11extras-${QT_PV} )
+	xmlpatterns? ( >=dev-qt/qtxmlpatterns-${QT_PV} )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-python/shiboken/shiboken-9999.ebuild
+++ b/dev-python/shiboken/shiboken-9999.ebuild
@@ -23,16 +23,16 @@ IUSE="test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 # Minimum version of Qt required.
-QT_PV="5.6*:5"
+QT_PV="5.6:5"
 
 #FIXME: Add "sys-devel/clang:*" after switching to the "dev" branch.
 DEPEND="
 	${PYTHON_DEPS}
 	dev-libs/libxml2
 	dev-libs/libxslt
-	=dev-qt/qtcore-${QT_PV}
-	=dev-qt/qtxml-${QT_PV}
-	=dev-qt/qtxmlpatterns-${QT_PV}
+	>=dev-qt/qtcore-${QT_PV}
+	>=dev-qt/qtxml-${QT_PV}
+	>=dev-qt/qtxmlpatterns-${QT_PV}
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
On ~amd64 dev-qt/qtcore-5.7.1-r3:5/5.7::gentoo is current, so when I did "layman -a qt" and tried to install pyside-9999 I got slot conflicts and it wanted to downgrade every dep QT package to 5.6. The comment QT_PV indicates it's supposed to be a minimal QT version, this patch makes it so.

Unfortunately, I hit an "unrelated" pyside compile error with qtcore5.7, but I'll report that to the pyside folks.