### PR TITLE
Fix bug #620348 - dev-qt/qtgui-5.9.0[-dbus] fails to build - Project ERROR: Unknown module(s) in QT_PRIVATE: dbus 

### DIFF
--- a/dev-qt/qtcore/qtcore-5.10.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.10.9999.ebuild
@@ -42,3 +42,25 @@ src_configure() {
 	)
 	qt5-build_src_configure
 }
+
+src_install() {
+	qt5-build_src_install
+
+	local flags=(
+			ALSA CUPS DBUS EGL EGLFS EGL_X11 EVDEV FONTCONFIG FREETYPE
+			HARFBUZZ IMAGEFORMAT_JPEG IMAGEFORMAT_PNG LIBPROXY MITSHM
+			OPENGL OPENSSL OPENVG PULSEAUDIO SHAPE SSL TSLIB XCURSOR
+			XFIXES XKB XRANDR XRENDER XSYNC ZLIB
+	)
+
+	for flag in ${flags[@]}; do
+		cat >> "${D%/}"/${QT5_HEADERDIR}/QtCore/qconfig.h <<- _EOF_ || die
+
+			#if defined(QT_NO_${flag}) && defined(QT_${flag})
+			# undef QT_NO_${flag}
+			#elif !defined(QT_NO_${flag}) && !defined(QT_${flag})
+			# define QT_NO_${flag}
+			#endif
+		_EOF_
+	done
+}

--- a/dev-qt/qtcore/qtcore-5.9.1.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9.1.ebuild
@@ -42,3 +42,25 @@ src_configure() {
 	)
 	qt5-build_src_configure
 }
+
+src_install() {
+	qt5-build_src_install
+
+	local flags=(
+			ALSA CUPS DBUS EGL EGLFS EGL_X11 EVDEV FONTCONFIG FREETYPE
+			HARFBUZZ IMAGEFORMAT_JPEG IMAGEFORMAT_PNG LIBPROXY MITSHM
+			OPENGL OPENSSL OPENVG PULSEAUDIO SHAPE SSL TSLIB XCURSOR
+			XFIXES XKB XRANDR XRENDER XSYNC ZLIB
+	)
+
+	for flag in ${flags[@]}; do
+		cat >> "${D%/}"/${QT5_HEADERDIR}/QtCore/qconfig.h <<- _EOF_ || die
+
+			#if defined(QT_NO_${flag}) && defined(QT_${flag})
+			# undef QT_NO_${flag}
+			#elif !defined(QT_NO_${flag}) && !defined(QT_${flag})
+			# define QT_NO_${flag}
+			#endif
+		_EOF_
+	done
+}

--- a/dev-qt/qtcore/qtcore-5.9.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9.9999.ebuild
@@ -42,3 +42,25 @@ src_configure() {
 	)
 	qt5-build_src_configure
 }
+
+src_install() {
+	qt5-build_src_install
+
+	local flags=(
+			ALSA CUPS DBUS EGL EGLFS EGL_X11 EVDEV FONTCONFIG FREETYPE
+			HARFBUZZ IMAGEFORMAT_JPEG IMAGEFORMAT_PNG LIBPROXY MITSHM
+			OPENGL OPENSSL OPENVG PULSEAUDIO SHAPE SSL TSLIB XCURSOR
+			XFIXES XKB XRANDR XRENDER XSYNC ZLIB
+	)
+
+	for flag in ${flags[@]}; do
+		cat >> "${D%/}"/${QT5_HEADERDIR}/QtCore/qconfig.h <<- _EOF_ || die
+
+			#if defined(QT_NO_${flag}) && defined(QT_${flag})
+			# undef QT_NO_${flag}
+			#elif !defined(QT_NO_${flag}) && !defined(QT_${flag})
+			# define QT_NO_${flag}
+			#endif
+		_EOF_
+	done
+}

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -42,3 +42,25 @@ src_configure() {
 	)
 	qt5-build_src_configure
 }
+
+src_install() {
+	qt5-build_src_install
+
+	local flags=(
+			ALSA CUPS DBUS EGL EGLFS EGL_X11 EVDEV FONTCONFIG FREETYPE
+			HARFBUZZ IMAGEFORMAT_JPEG IMAGEFORMAT_PNG LIBPROXY MITSHM
+			OPENGL OPENSSL OPENVG PULSEAUDIO SHAPE SSL TSLIB XCURSOR
+			XFIXES XKB XRANDR XRENDER XSYNC ZLIB
+	)
+
+	for flag in ${flags[@]}; do
+		cat >> "${D%/}"/${QT5_HEADERDIR}/QtCore/qconfig.h <<- _EOF_ || die
+
+			#if defined(QT_NO_${flag}) && defined(QT_${flag})
+			# undef QT_NO_${flag}
+			#elif !defined(QT_NO_${flag}) && !defined(QT_${flag})
+			# define QT_NO_${flag}
+			#endif
+		_EOF_
+	done
+}

--- a/dev-qt/qtwebengine/qtwebengine-5.9.1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.1.ebuild
@@ -74,6 +74,9 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-5.9.0-paxmark-mksnapshot.patch" )
 
+	# bug 620444 - ensure local headers are used
+	find "${S}" -name "*.pr*" | xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |' src/webengine/webengine.pro || die
+
 	qt_use_disable_config alsa alsa src/core/config/linux.pri
 	qt_use_disable_config pulseaudio pulseaudio src/core/config/linux.pri
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9.9999.ebuild
@@ -74,6 +74,9 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-5.9.0-paxmark-mksnapshot.patch" )
 
+	# bug 620444 - ensure local headers are used
+	find "${S}" -name "*.pr*" | xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |' src/webengine/webengine.pro || die
+
 	qt_use_disable_config alsa alsa src/core/config/linux.pri
 	qt_use_disable_config pulseaudio pulseaudio src/core/config/linux.pri
 

--- a/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.9999.ebuild
@@ -74,6 +74,9 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	use pax_kernel && PATCHES+=( "${FILESDIR}/${PN}-5.9.0-paxmark-mksnapshot.patch" )
 
+	# bug 620444 - ensure local headers are used
+	find "${S}" -name "*.pr*" | xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |' src/webengine/webengine.pro || die
+
 	qt_use_disable_config alsa alsa src/core/config/linux.pri
 	qt_use_disable_config pulseaudio pulseaudio src/core/config/linux.pri
 

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -615,12 +615,7 @@ qt5_base_configure() {
 		$([[ ${QT5_MINOR_VERSION} -lt 8 ]] && echo -iconv)
 
 		# disable everything to prevent automagic deps (part 3)
-		-no-cups -no-evdev -no-tslib -no-icu -no-fontconfig
-
-		# FIXME
-		# since 5.8, disabling dbus generates a QT_NO_DBUS in QtCore/qconfig.h,
-		# thus specify runtime loading of libdbus to avoid the #define
-		$([[ ${QT5_MINOR_VERSION} -ge 8 ]] && echo -dbus-runtime || echo -no-dbus)
+		-no-cups -no-evdev -no-tslib -no-icu -no-fontconfig -no-dbus
 
 		# let portage handle stripping
 		-no-strip
@@ -684,6 +679,12 @@ qt5_base_configure() {
 	"${S}"/configure "${conf[@]}" || die "configure failed"
 
 	popd >/dev/null || die
+
+	if [[ ${QT5_MINOR_VERSION} -ge 8 ]]; then
+		# a forwarding header is no longer created since 5.8, causing the system
+		# config to always be used. bug 599636
+		cp src/corelib/global/qconfig.h include/QtCore/ || die
+	fi
 }
 
 # @FUNCTION: qt5_qmake


### PR DESCRIPTION
This basically replicates some stuff that was removed upstream in 5.8 that we relied on to make split qtbase work.