### PR TITLE
dev-qt/qtnetwork: fix OpenSSL 1.1.1 build DO NOT MERGE

### DIFF
--- a/dev-qt/qtnetwork/files/backport_opensslv11.patch
+++ b/dev-qt/qtnetwork/files/backport_opensslv11.patch
@@ -1,0 +1,56 @@
+From e365993b72d64db441f3940d6c255e3dbb2ad76a Mon Sep 17 00:00:00 2001
+From: Timur Pocheptsov <timur.pocheptsov@qt.io>
+Date: Thu, 1 Feb 2018 16:12:49 +0100
+Subject: Fix configure.json for opensslv11 feature
+
+Both the test/feature had some errors (incorrect
+"use" and incomplete "condition") + remove "feature".
+
+Task-number: QTBUG-62733
+Change-Id: If4b8d2fe080d8fba961231834839afadaed0f0c5
+Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@qt.io>
+---
+ src/network/configure.json | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/src/network/configure.json b/src/network/configure.json
+index 770921f9a6..2f446becf1 100644
+--- a/src/network/configure.json
++++ b/src/network/configure.json
+@@ -123,10 +123,10 @@
+             "use": "network"
+         },
+         "openssl11": {
+-            "label": "OpenSSL v. 1.1 support",
++            "label": "OpenSSL 1.1 support",
+             "type": "compile",
+             "test": "unix/openssl11",
+-            "use": "network"
++            "use": "openssl"
+         }
+     },
+ 
+@@ -190,9 +190,9 @@
+             "output": [ "publicFeature", "feature" ]
+         },
+         "opensslv11": {
+-            "label": "OpenSSL v. 1.1",
+-            "condition": "tests.openssl11",
+-            "output": ["publicFeature", "feature"]
++            "label": "OpenSSL 1.1",
++            "condition": "features.openssl && tests.openssl11",
++            "output": [ "publicFeature" ]
+         },
+         "sctp": {
+             "label": "SCTP",
+@@ -307,6 +307,7 @@ For example:
+                 },
+                 "openssl",
+                 "openssl-linked",
++                "opensslv11",
+                 "sctp",
+                 "system-proxies"
+             ]
+-- 
+cgit v1.1-6-g87c4
+

--- a/dev-qt/qtnetwork/files/backport_use_QT_CONFIG.patch
+++ b/dev-qt/qtnetwork/files/backport_use_QT_CONFIG.patch
@@ -1,0 +1,64 @@
+From 16b76456be8d00ca70715286906b7c482a158dc4 Mon Sep 17 00:00:00 2001
+From: Timur Pocheptsov <timur.pocheptsov@qt.io>
+Date: Mon, 6 Nov 2017 12:22:18 +0100
+Subject: QSsl: use QT_CONFIG(feature) instead of hardcoded constant
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The test OPENSSL_VERSION_NUMBER >= 0x1010000000L was introduced before
+1.1 support. Now a couple of conditional inclusions can be converted
+into QT_CONFIG(opensslv11).
+
+Task-number: QTBUG-64275
+Change-Id: I627e6b06f334deac70c827e463ecbfad879dfc24
+Reviewed-by: Mårten Nordheim <marten.nordheim@qt.io>
+Reviewed-by: Edward Welbourne <edward.welbourne@qt.io>
+---
+ src/network/ssl/qsslsocket_openssl_symbols.cpp | 2 +-
+ src/network/ssl/qsslsocket_openssl_symbols_p.h | 8 +++++---
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols.cpp b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+index 3a236a1300..1b73135935 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -1017,7 +1017,7 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(EC_GROUP_get_degree)
+ #endif
+     RESOLVEFUNC(BN_num_bits)
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if QT_CONFIG(opensslv11)
+     RESOLVEFUNC(BN_is_word)
+ #endif
+     RESOLVEFUNC(BN_mod_word)
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols_p.h b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+index 796bf2d4f5..4cad0231cd 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
++++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+@@ -232,9 +232,10 @@ BIO *q_BIO_new_mem_buf(void *a, int b);
+ int q_BIO_read(BIO *a, void *b, int c);
+ Q_AUTOTEST_EXPORT int q_BIO_write(BIO *a, const void *b, int c);
+ int q_BN_num_bits(const BIGNUM *a);
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++
++#if QT_CONFIG(opensslv11)
+ int q_BN_is_word(BIGNUM *a, BN_ULONG w);
+-#else
++#else // opensslv11
+ // BN_is_word is implemented purely as a
+ // macro in OpenSSL < 1.1. It doesn't
+ // call any functions.
+@@ -245,7 +246,8 @@ int q_BN_is_word(BIGNUM *a, BN_ULONG w);
+ //
+ // Users are required to include <openssl/bn.h>.
+ #define q_BN_is_word BN_is_word
+-#endif // OPENSSL_VERSION_NUMBER >= 0x10100000L
++#endif // !opensslv11
++
+ BN_ULONG q_BN_mod_word(const BIGNUM *a, BN_ULONG w);
+ #ifndef OPENSSL_NO_EC
+ const EC_GROUP* q_EC_KEY_get0_group(const EC_KEY* k);
+-- 
+cgit v1.1-6-g87c4
+

--- a/dev-qt/qtnetwork/files/qt-openssl-v111_support-part1_tests.patch
+++ b/dev-qt/qtnetwork/files/qt-openssl-v111_support-part1_tests.patch
@@ -1,0 +1,12 @@
+diff -Naur a/config.tests/openssl/openssl.cpp b/config.tests/openssl/openssl.cpp
+--- a/config.tests/openssl/openssl.cpp	2018-02-08 19:24:48.000000000 +0100
++++ b/config.tests/openssl/openssl.cpp	2018-04-02 09:39:01.869229154 +0200
+@@ -45,7 +45,7 @@
+ 
+ #include <openssl/ssl.h>
+ 
+-#if OPENSSL_VERSION_NUMBER-0 >= 0x10002000L && !defined(OPENSSL_NO_EC) && !defined(SSL_CTRL_SET_CURVES)
++#if (OPENSSL_VERSION_NUMBER-0 <= 0x10100000L) && (OPENSSL_VERSION_NUMBER-0 >= 0x10002000L && !defined(OPENSSL_NO_EC) && !defined(SSL_CTRL_SET_CURVES))
+ #  error "OpenSSL was reported as >= 1.0.2 but is missing required features, possibly it's libressl which is unsupported"
+ #endif
+ 

--- a/dev-qt/qtnetwork/files/qt-openssl-v111_support-part2_nocurves.patch
+++ b/dev-qt/qtnetwork/files/qt-openssl-v111_support-part2_nocurves.patch
@@ -1,0 +1,17 @@
+diff -Naur a/src/network/ssl/qsslcontext_openssl11.cpp b/src/network/ssl/qsslcontext_openssl11.cpp
+--- a/src/network/ssl/qsslcontext_openssl11.cpp	2018-02-08 19:24:48.000000000 +0100
++++ b/src/network/ssl/qsslcontext_openssl11.cpp	2018-04-01 23:10:42.950616822 +0200
+@@ -266,11 +266,13 @@
+         curves.reserve(qcurves.size());
+         for (const auto &sslCurve : qcurves)
+             curves.push_back(sslCurve.id);
++#ifdef SSL_CTRL_SET_CURVES
+         if (!q_SSL_CTX_ctrl(sslContext->ctx, SSL_CTRL_SET_CURVES, long(curves.size()), &curves[0])) {
+             sslContext->errorStr = msgErrorSettingEllipticCurves(QSslSocketBackendPrivate::getErrorsFromOpenSsl());
+             sslContext->errorCode = QSslError::UnspecifiedError;
+         }
+ #endif
++#endif
+     }
+ }
+ 

--- a/dev-qt/qtnetwork/qtnetwork-5.10.1.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.10.1.ebuild
@@ -47,6 +47,15 @@ pkg_setup() {
 	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
 }
 
+src_prepare() {
+	epatch ${FILESDIR}/"backport_opensslv11.patch"
+	epatch ${FILESDIR}/"backport_use_QT_CONFIG.patch"
+	epatch ${FILESDIR}/"qt-openssl-v111_support-part1_tests.patch"
+	epatch ${FILESDIR}/"qt-openssl-v111_support-part2_nocurves.patch"
+
+	qt5-build_src_prepare
+}
+
 src_configure() {
 	local myconf=(
 		$(use connman || use networkmanager && echo -dbus-linked)


### PR DESCRIPTION
This patches make qtnetwork work with OpenSSL 1.1.1_pre3,
based on https://bugreports.qt.io/browse/QTBUG-62016

Signed-off-by: David Heidelberg <david@ixit.cz>