### PR TITLE
dev-qt/qtcore: Restore qt5_use_modules macro

### DIFF
--- a/dev-qt/qtcore/files/qtcore-5.11.0-restore-qt5_use_modules.patch
+++ b/dev-qt/qtcore/files/qtcore-5.11.0-restore-qt5_use_modules.patch
@@ -1,0 +1,224 @@
+From d1bbe4acbd8ce09f8f4263bca1aa5682c6559c23 Mon Sep 17 00:00:00 2001
+From: Kevin Funk <kevin.funk@kdab.com>
+Date: Thu, 14 Jun 2018 14:50:39 +0200
+Subject: [PATCH] CMake: Restore qt5_use_modules() function
+
+It appears that in the 5 years since we deprecated this function, people
+have not stopped using it. The removal of qt5_use_modules() caused lots of
+troubles in packages still using it when they were compiled against Qt 5.11.0.
+
+Instead, let's revive this function and keep it for the Qt5 life time.
+
+See discussion on qt-development mailing list:
+  http://lists.qt-project.org/pipermail/development/2018-June/032837.html
+
+Change-Id: Ic263e3bb6706268cb9ea38a0711665f166a3aa9e
+---
+ src/corelib/Qt5CoreMacros.cmake                    | 51 ++++++++++++++++++++++
+ tests/auto/cmake/CMakeLists.txt                    |  1 +
+ .../cmake/test_use_modules_function/CMakeLists.txt | 18 ++++++++
+ .../auto/cmake/test_use_modules_function/three.cpp | 45 +++++++++++++++++++
+ tests/auto/cmake/test_use_modules_function/two.cpp | 43 ++++++++++++++++++
+ 5 files changed, 158 insertions(+)
+ create mode 100644 tests/auto/cmake/test_use_modules_function/CMakeLists.txt
+ create mode 100644 tests/auto/cmake/test_use_modules_function/three.cpp
+ create mode 100644 tests/auto/cmake/test_use_modules_function/two.cpp
+
+diff --git a/src/corelib/Qt5CoreMacros.cmake b/src/corelib/Qt5CoreMacros.cmake
+index 1627de40029..819b48f9734 100644
+--- a/src/corelib/Qt5CoreMacros.cmake
++++ b/src/corelib/Qt5CoreMacros.cmake
+@@ -294,3 +294,54 @@ function(QT5_ADD_RESOURCES outfiles )
+ endfunction()
+ 
+ set(_Qt5_COMPONENT_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
++
++if (NOT CMAKE_VERSION VERSION_LESS 2.8.9)
++    macro(qt5_use_modules _target _link_type)
++        if(NOT CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 2.8.11)
++            if(CMAKE_WARN_DEPRECATED)
++                set(messageType WARNING)
++            endif()
++            if(CMAKE_ERROR_DEPRECATED)
++                set(messageType FATAL_ERROR)
++            endif()
++            if(messageType)
++                message(${messageType} "The qt5_use_modules macro is obsolete. Use target_link_libraries with IMPORTED targets instead.")
++            endif()
++        endif()
++
++        if (NOT TARGET ${_target})
++            message(FATAL_ERROR "The first argument to qt5_use_modules must be an existing target.")
++        endif()
++        if ("${_link_type}" STREQUAL "LINK_PUBLIC" OR "${_link_type}" STREQUAL "LINK_PRIVATE" )
++            set(_qt5_modules ${ARGN})
++            set(_qt5_link_type ${_link_type})
++        else()
++            set(_qt5_modules ${_link_type} ${ARGN})
++        endif()
++
++        if ("${_qt5_modules}" STREQUAL "")
++            message(FATAL_ERROR "qt5_use_modules requires at least one Qt module to use.")
++        endif()
++
++        foreach(_module ${_qt5_modules})
++            if (NOT Qt5${_module}_FOUND)
++                find_package(Qt5${_module} PATHS "${_Qt5_COMPONENT_PATH}" NO_DEFAULT_PATH)
++                if (NOT Qt5${_module}_FOUND)
++                    message(FATAL_ERROR "Can not use \"${_module}\" module which has not yet been found.")
++                endif()
++            endif()
++            target_link_libraries(${_target} ${_qt5_link_type} ${Qt5${_module}_LIBRARIES})
++            set_property(TARGET ${_target} APPEND PROPERTY INCLUDE_DIRECTORIES ${Qt5${_module}_INCLUDE_DIRS})
++            set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS ${Qt5${_module}_COMPILE_DEFINITIONS})
++            set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE QT_NO_DEBUG)
++            set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS_RELWITHDEBINFO QT_NO_DEBUG)
++            set_property(TARGET ${_target} APPEND PROPERTY COMPILE_DEFINITIONS_MINSIZEREL QT_NO_DEBUG)
++            if (Qt5_POSITION_INDEPENDENT_CODE
++                    AND (CMAKE_VERSION VERSION_LESS 2.8.12
++                        AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
++                        OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)))
++                set_property(TARGET ${_target} PROPERTY POSITION_INDEPENDENT_CODE ${Qt5_POSITION_INDEPENDENT_CODE})
++            endif()
++        endforeach()
++    endmacro()
++endif()
+diff --git a/tests/auto/cmake/CMakeLists.txt b/tests/auto/cmake/CMakeLists.txt
+index f1d86570919..ec75ec7caf7 100644
+--- a/tests/auto/cmake/CMakeLists.txt
++++ b/tests/auto/cmake/CMakeLists.txt
+@@ -47,6 +47,7 @@ find_package(Qt5Core REQUIRED)
+ 
+ include("${_Qt5CTestMacros}")
+ 
++expect_pass(test_use_modules_function)
+ expect_pass(test_umbrella_config)
+ expect_pass(test_wrap_cpp_and_resources)
+ if (NOT NO_WIDGETS)
+diff --git a/tests/auto/cmake/test_use_modules_function/CMakeLists.txt b/tests/auto/cmake/test_use_modules_function/CMakeLists.txt
+new file mode 100644
+index 00000000000..be05c75054c
+--- /dev/null
++++ b/tests/auto/cmake/test_use_modules_function/CMakeLists.txt
+@@ -0,0 +1,18 @@
++
++cmake_minimum_required(VERSION 2.8)
++
++project(test_use_modules_function)
++
++set(CMAKE_AUTOMOC ON)
++
++set(CMAKE_INCLUDE_CURRENT_DIR ON)
++
++add_executable(two two.cpp)
++add_executable(three three.cpp)
++
++find_package(Qt5Core)
++
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
++
++qt5_use_modules(two Test)
++qt5_use_modules(three Gui Test)
+diff --git a/tests/auto/cmake/test_use_modules_function/three.cpp b/tests/auto/cmake/test_use_modules_function/three.cpp
+new file mode 100644
+index 00000000000..507cc8479d0
+--- /dev/null
++++ b/tests/auto/cmake/test_use_modules_function/three.cpp
+@@ -0,0 +1,45 @@
++/****************************************************************************
++**
++** Copyright (C) 2011 KlarÃ¤lvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Stephen Kelly <stephen.kelly@kdab.com>
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the test suite of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:GPL-EXCEPT$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 3 as published by the Free Software
++** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include <QtTest>
++#include <QWindow>
++
++class Three : public QObject
++{
++    Q_OBJECT
++public:
++    Three(QObject *parent = 0)
++    {
++        QWindow *w = new QWindow;
++        w->show();
++    }
++};
++
++QTEST_MAIN(Three)
++
++#include "three.moc"
+diff --git a/tests/auto/cmake/test_use_modules_function/two.cpp b/tests/auto/cmake/test_use_modules_function/two.cpp
+new file mode 100644
+index 00000000000..44eb7fe96e3
+--- /dev/null
++++ b/tests/auto/cmake/test_use_modules_function/two.cpp
+@@ -0,0 +1,43 @@
++/****************************************************************************
++**
++** Copyright (C) 2011 KlarÃ¤lvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Stephen Kelly <stephen.kelly@kdab.com>
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the test suite of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:GPL-EXCEPT$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 3 as published by the Free Software
++** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include <QtTest>
++
++class Two : public QObject
++{
++    Q_OBJECT
++public:
++    Two(QObject *parent = 0)
++    {
++
++    }
++};
++
++QTEST_MAIN(Two)
++
++#include "two.moc"
+-- 
+2.16.3
+

--- a/dev-qt/qtcore/qtcore-5.11.0.ebuild
+++ b/dev-qt/qtcore/qtcore-5.11.0.ebuild
@@ -43,6 +43,8 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 	!:xml
 )
 
+PATCHES=( "${FILESDIR}/${P}-restore-qt5_use_modules.patch" )
+
 src_configure() {
 	local myconf=(
 		$(qt_use icu)


### PR DESCRIPTION
This is certainly better than spending even more energy on fixing upstreams.

See also: https://codereview.qt-project.org/#/c/232367/

Bug: https://bugs.gentoo.org/653646
Package-Manager: Portage-2.3.40, Repoman-2.3.9