### PR TITLE
dev-qt/qtgui: bundled xkbcommon is gone, option renamed to xkbcommon

### DIFF
--- a/dev-qt/qtgui/qtgui-5.12.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.12.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -55,7 +55,7 @@ RDEPEND="
 		x11-libs/libSM
 		x11-libs/libX11
 		>=x11-libs/libxcb-1.12:=[xkb]
-		>=x11-libs/libxkbcommon-0.4.1[X]
+		>=x11-libs/libxkbcommon-0.5.0[X]
 		x11-libs/xcb-util-image
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil
@@ -102,7 +102,7 @@ QT5_GENTOO_CONFIG=(
 	jpeg:system-jpeg:IMAGEFORMAT_JPEG
 	!jpeg:no-jpeg:
 	libinput
-	libinput:xkbcommon-evdev:
+	libinput:xkbcommon:
 	:opengl
 	png:png:
 	png:system-png:IMAGEFORMAT_PNG
@@ -156,14 +156,15 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		$(qt_use libinput xkbcommon-evdev)
 		-opengl $(usex gles2 es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)
 		$(qt_use xcb xcb system)
-		$(qt_use xcb xkbcommon-x11 system)
 		$(usex xcb '-xcb-xlib -xcb-xinput -xkb' '')
 	)
+	if use libinput || use xcb; then
+		myconf+=( -xkbcommon )
+	fi
 	qt5-build_src_configure
 }

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -55,7 +55,7 @@ RDEPEND="
 		x11-libs/libSM
 		x11-libs/libX11
 		>=x11-libs/libxcb-1.12:=[xkb]
-		>=x11-libs/libxkbcommon-0.4.1[X]
+		>=x11-libs/libxkbcommon-0.5.0[X]
 		x11-libs/xcb-util-image
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil
@@ -102,7 +102,7 @@ QT5_GENTOO_CONFIG=(
 	jpeg:system-jpeg:IMAGEFORMAT_JPEG
 	!jpeg:no-jpeg:
 	libinput
-	libinput:xkbcommon-evdev:
+	libinput:xkbcommon:
 	:opengl
 	png:png:
 	png:system-png:IMAGEFORMAT_PNG
@@ -156,14 +156,15 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		$(qt_use libinput xkbcommon-evdev)
 		-opengl $(usex gles2 es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)
 		$(qt_use xcb xcb system)
-		$(qt_use xcb xkbcommon-x11 system)
 		$(usex xcb '-xcb-xlib -xcb-xinput -xkb' '')
 	)
+	if use libinput || use xcb; then
+		myconf+=( -xkbcommon )
+	fi
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwayland/qtwayland-5.11.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.11.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
@@ -31,6 +31,10 @@ src_prepare() {
 		src/client/client.pro \
 		src/compositor/wayland_wrapper/wayland_wrapper.pri \
 		src/plugins/shellintegration/ivi-shell/ivi-shell.pro \
+		src/plugins/shellintegration/wl-shell/wl-shell.pro \
+		src/plugins/shellintegration/xdg-shell/xdg-shell.pro \
+		src/plugins/shellintegration/xdg-shell-v5/xdg-shell-v5.pro \
+		src/plugins/shellintegration/xdg-shell-v6/xdg-shell-v6.pro \
 		tests/auto/compositor/compositor/compositor.pro
 
 	use xcomposite || rm -r config.tests/xcomposite || die

--- a/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,6 +31,10 @@ src_prepare() {
 		src/client/client.pro \
 		src/compositor/wayland_wrapper/wayland_wrapper.pri \
 		src/plugins/shellintegration/ivi-shell/ivi-shell.pro \
+		src/plugins/shellintegration/wl-shell/wl-shell.pro \
+		src/plugins/shellintegration/xdg-shell/xdg-shell.pro \
+		src/plugins/shellintegration/xdg-shell-v5/xdg-shell-v5.pro \
+		src/plugins/shellintegration/xdg-shell-v6/xdg-shell-v6.pro \
 		tests/auto/compositor/compositor/compositor.pro
 
 	use xcomposite || rm -r config.tests/xcomposite || die

--- a/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -31,6 +31,10 @@ src_prepare() {
 		src/client/client.pro \
 		src/compositor/wayland_wrapper/wayland_wrapper.pri \
 		src/plugins/shellintegration/ivi-shell/ivi-shell.pro \
+		src/plugins/shellintegration/wl-shell/wl-shell.pro \
+		src/plugins/shellintegration/xdg-shell/xdg-shell.pro \
+		src/plugins/shellintegration/xdg-shell-v5/xdg-shell-v5.pro \
+		src/plugins/shellintegration/xdg-shell-v6/xdg-shell-v6.pro \
 		tests/auto/compositor/compositor/compositor.pro
 
 	use xcomposite || rm -r config.tests/xcomposite || die

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -612,10 +612,10 @@ qt5_base_configure() {
 		-no-libpng -no-libjpeg
 		-no-freetype -no-harfbuzz
 		-no-openssl -no-libproxy
-		-no-xkbcommon-x11 -no-xkbcommon-evdev
 		-no-xcb-xlib
-		$([[ ${QT5_MINOR_VERSION} -lt 12 ]] && echo -no-xinput2)
-		$([[ ${QT5_MINOR_VERSION} -ge 12 ]] && echo -no-xcb-xinput)
+		$([[ ${QT5_MINOR_VERSION} -lt 12 ]] && echo -no-xinput2 -no-xkbcommon-x11 -no-xkbcommon-evdev)
+		$([[ ${PV} = 5.12.0* ]] && echo -no-xcb-xinput -no-xkbcommon-x11 -no-xkbcommon-evdev) # bug 672340
+		$([[ ${QT5_MINOR_VERSION} -ge 12 && ${PV} != 5.12.0* ]] && echo -no-xcb-xinput -no-xkbcommon) # bug 672340
 
 		# cannot use -no-gif because there is no way to override it later
 		#-no-gif


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/672340

See also: https://bugreports.qt.io/browse/QTBUG-65503