### PR TITLE
dev-qt/qtlocation: Add USE-DEPEND on dev-qt/qtpositioning[qml]

### DIFF
--- a/dev-qt/qtlocation/qtlocation-5.11.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.11.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ RDEPEND="
 	~dev-qt/qtdeclarative-${PV}
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
-	~dev-qt/qtpositioning-${PV}
+	~dev-qt/qtpositioning-${PV}[qml]
 	~dev-qt/qtsql-${PV}
 	sys-libs/zlib
 "

--- a/dev-qt/qtlocation/qtlocation-5.12.0_rc.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.12.0_rc.ebuild
@@ -17,7 +17,7 @@ RDEPEND="
 	~dev-qt/qtdeclarative-${PV}
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
-	~dev-qt/qtpositioning-${PV}
+	~dev-qt/qtpositioning-${PV}[qml]
 	~dev-qt/qtsql-${PV}
 	sys-libs/zlib
 "

--- a/dev-qt/qtlocation/qtlocation-5.12.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.12.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ RDEPEND="
 	~dev-qt/qtdeclarative-${PV}
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
-	~dev-qt/qtpositioning-${PV}
+	~dev-qt/qtpositioning-${PV}[qml]
 	~dev-qt/qtsql-${PV}
 	sys-libs/zlib
 "

--- a/dev-qt/qtlocation/qtlocation-5.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ RDEPEND="
 	~dev-qt/qtdeclarative-${PV}
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
-	~dev-qt/qtpositioning-${PV}
+	~dev-qt/qtpositioning-${PV}[qml]
 	~dev-qt/qtsql-${PV}
 	sys-libs/zlib
 "

--- a/dev-qt/qtpositioning/qtpositioning-5.11.9999.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.11.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="geoclue qml"
+IUSE="geoclue +qml"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}

--- a/dev-qt/qtpositioning/qtpositioning-5.12.0_rc.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.12.0_rc.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="geoclue qml"
+IUSE="geoclue +qml"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}

--- a/dev-qt/qtpositioning/qtpositioning-5.12.9999.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.12.9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="geoclue qml"
+IUSE="geoclue +qml"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}

--- a/dev-qt/qtpositioning/qtpositioning-5.9999.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="geoclue qml"
+IUSE="geoclue +qml"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}

--- a/dev-qt/qtwayland/qtwayland-5.11.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.11.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.0_rc.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.12.9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -16,7 +16,7 @@ DEPEND="
 	>=dev-libs/wayland-1.6.0
 	~dev-qt/qtcore-${PV}
 	~dev-qt/qtdeclarative-${PV}
-	~dev-qt/qtgui-${PV}[egl,libinput?]
+	~dev-qt/qtgui-${PV}[egl,libinput=]
 	media-libs/mesa[egl]
 	>=x11-libs/libxkbcommon-0.2.0
 	xcomposite? (


### PR DESCRIPTION
For usage of QtPositioningQuick.

While location-labs-plugin is optional, declarativemaps is built and depends on
QtPositioningQuick unconditionally. It is probably for this reason that ${PN}
already unconditionally depends on dev-qt/qtdeclarative, so making the plugin
optional would save us nothing.

Bug: https://bugs.gentoo.org/669608