### PR TITLE
dev-libs/libqtxdg: add missing BDEPEND lxqt-build-tools

### DIFF
--- a/dev-libs/libqtxdg/libqtxdg-9999.ebuild
+++ b/dev-libs/libqtxdg/libqtxdg-9999.ebuild
@@ -21,6 +21,7 @@ SLOT="0"
 IUSE="test"
 
 BDEPEND="
+	>=dev-util/lxqt-build-tools-0.6.0
 	virtual/pkgconfig
 "
 RDEPEND="


### PR DESCRIPTION
`lxqt-build-tools` is a BDEPEND of this package, as shown in [this](https://github.com/lxqt/libqtxdg/blob/master/CMakeLists.txt#L23) line.
In the version in main repository (v3.3.1), the dependency is there.

Package-Manager: Portage-2.3.62, Repoman-2.3.12