### PR TITLE
qtlocation: Fix build of 5.13

### DIFF
--- a/dev-qt/qtlocation/qtlocation-5.13.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.13.9999.ebuild
@@ -32,6 +32,7 @@ QT5_TARGET_SUBDIRS=(
 	src/3rdparty/mapbox-gl-native
 	src/location
 	src/imports/location
+	src/imports/locationlabs
 	src/plugins/geoservices
 )
 

--- a/dev-qt/qtlocation/qtlocation-5.9999.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.9999.ebuild
@@ -32,6 +32,7 @@ QT5_TARGET_SUBDIRS=(
 	src/3rdparty/mapbox-gl-native
 	src/location
 	src/imports/location
+	src/imports/locationlabs
 	src/plugins/geoservices
 )
 


### PR DESCRIPTION
Without this patch, the build fails with qmake's error message:
```
Project ERROR: Could not find feature location-labs-plugin.
```
Tested on `5.13.9999`; the `5.9999` (targetting the dev branch upstream) is untested.