### PR TITLE
app-arch/lxqt-archiver: add RDEPEND dev-libs/json-glib

### DIFF
--- a/app-arch/lxqt-archiver/lxqt-archiver-9999.ebuild
+++ b/app-arch/lxqt-archiver/lxqt-archiver-9999.ebuild
@@ -24,6 +24,7 @@ BDEPEND="
 	>=dev-util/lxqt-build-tools-0.6.0
 "
 RDEPEND="
+	dev-libs/json-glib
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
`lxqt-archiver` depends on `json-glib`, as found from [CMakeLists.txt](https://github.com/lxqt/lxqt-archiver/blob/master/CMakeLists.txt) and from `ldd /usr/bin/lxqt-archiver | grep libjson-glib`.

Package-Manager: Portage-2.3.67, Repoman-2.3.14