### PR TITLE
dev-python/shiboken: fix python versioning in cmake targets

### DIFF
--- a/dev-python/shiboken/shiboken-5.12.4-r1.ebuild
+++ b/dev-python/shiboken/shiboken-5.12.4-r1.ebuild
@@ -98,7 +98,19 @@ src_test() {
 src_install() {
 	shiboken_install() {
 		cmake-utils_src_install
+
+		# Uniquify this pkgconfig file to a version-specific basename. Although
+		# each successive call to this function overwrites the original file,
+		# copying rather than moving this file ensures that an original file
+		# targetting the last Python target is still usable by third parties.
 		cp "${ED}/usr/$(get_libdir)"/pkgconfig/${PN}2{,-${EPYTHON}}.pc || die
 	}
 	python_foreach_impl shiboken_install
+
+	# CMakeLists.txt installs a "Shiboken2Targets-gentoo.cmake" file forcing
+	# downstream consumers (e.g., PySide2) to target one "libshiboken2-*.so"
+	# library linked to a single Python interpreter. See also:
+	#     https://bugreports.qt.io/browse/PYSIDE-1053
+	sed -i -e 's~libshiboken2-python[[:digit:]]\+\.[[:digit:]]\+~libshiboken2${PYTHON_CONFIG_SUFFIX}~g' \
+		"${ED}/usr/$(get_libdir)/cmake/Shiboken2-${PV}/Shiboken2Targets-gentoo.cmake" || die
 }


### PR DESCRIPTION
This is the next in a series of pull requests bumping PySide2 & Friends to the "recently" wink, wink released next stable version of PySide2: **PySide2 5.12.4.**

This PR patches the recently bumped Shiboken2 5.12.4 ebuild to resolve a [severe upstream build issue](https://bugreports.qt.io/browse/PYSIDE-1053) currently blocking #195, the last PR in this series. This PR is thus a mandatory dependency of #195. Once merged, #195 should have no further blockers.

...*should.* :anger: 

# ELI5 or I'm Outta

Currently, Shiboken2 usage is confined to a single Python interpreter – specifically the last Python interpreter against which Shiboken2 was built, which tends to be the highest enabled Python 3 interpreter under Gentoo. This has the obvious adverse effect of breaking Shiboken2 for every *other* enabled Python interpreter, which tends to be Python 2.7 and older enabled Python 3 interpreters under Gentoo.

For voluminous details, see also [**PYSIDE-1053**](https://bugreports.qt.io/browse/PYSIDE-1053).

# What Did You Do About This Horrible Thing?

**One-linered it,** of course! Thanks to the luck of the Canadian Irish, I've uncovered an even *more* efficient means of resolving this on our end than the [awfully convoluted two-step solution detailed at PYSIDE-1053](https://bugreports.qt.io/browse/PYSIDE-1053). That's nice. Here's how it works.

Through the magic of `sed`, we globally replace all *static* references to a specific `libshiboken2*.so` library within the auto-generated `/usr/lib64/cmake/Shiboken-5.12.4/Shiboken2Targets-gentoo.cmake` file (e.g., `/usr/lib64/libshiboken2-python3.6.so.5.12.4`) with *dynamic* references to the current `libshiboken2*.so` library being linked against by PySide2 (e.g., `/usr/lib64/libshiboken2${PYTHON_CONFIG_SUFFIX}.so.5.12.4`).

This works because our PySide2 ebuild will – *once bumped by #195, anyway* – override the `${PYTHON_CONFIG_SUFFIX}` cmake variable to an appropriate string specific to the current Python interpreter being installed against. Wondrous magic follows.

For no good reason, I also accidentally reverted the copying of `/usr/lib64/pkgconfig/shiboken2*.pc` files to mere moving of those files. Either way appears to behave as expected. Being fundamentally lazy, I left it as is. I'd be happy to revert this reversion. Just lemme know!

## I'm Outta

Shout-outs to @Pesa for his perpetual patience during this "process." The promised land is within sight.