### PR TITLE
qmake-utils.eclass: Drop obsolete EAPI-5 support

### DIFF
--- a/eclass/qmake-utils.eclass
+++ b/eclass/qmake-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: qmake-utils.eclass
@@ -6,7 +6,7 @@
 # qt@gentoo.org
 # @AUTHOR:
 # Davide Pesavento <pesa@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 6 7
 # @BLURB: Common functions for qmake-based packages.
 # @DESCRIPTION:
 # Utility eclass providing wrapper functions for Qt4 and Qt5 qmake.
@@ -17,9 +17,8 @@
 if [[ -z ${_QMAKE_UTILS_ECLASS} ]]; then
 _QMAKE_UTILS_ECLASS=1
 
-[[ ${EAPI:-0} == [01234] ]] && die "qmake-utils.eclass: unsupported EAPI=${EAPI:-0}"
+[[ ${EAPI:-0} == [012345] ]] && die "qmake-utils.eclass: unsupported EAPI=${EAPI:-0}"
 
-[[ ${EAPI:-0} == 5 ]] && inherit eutils multilib
 inherit estack toolchain-funcs
 
 # @FUNCTION: qt4_get_bindir


### PR DESCRIPTION
Last consumer in Gentoo ebuild repository was dropped.

Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>