### PR TITLE
eclass: do not pass "-nomake tests" to configure when we want Qt tests

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -582,7 +582,7 @@ qt5_base_configure() {
 
 		# exclude examples and tests from default build
 		-nomake examples
-		-nomake tests
+		$(usex test '' '-nomake tests')
 		-no-compile-examples
 
 		# disable rpath on non-prefix (bugs 380415 and 417169)

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -208,9 +208,6 @@ qt5-build_src_compile() {
 # @DESCRIPTION:
 # Runs tests in the target directories.
 qt5-build_src_test() {
-	# disable broken cmake tests (bug 474004)
-	local myqmakeargs=("${myqmakeargs[@]}" -after SUBDIRS-=cmake SUBDIRS-=installed_cmake)
-
 	qt5_foreach_target_subdir qt5_qmake
 	qt5_foreach_target_subdir emake
 
@@ -649,6 +646,11 @@ qt5_base_configure() {
 		# module-specific options
 		"${myconf[@]}"
 	)
+
+	if [[ -f "${S}"/tests/auto/auto.pro ]] && use test; then
+		# disable broken cmake tests (bug 474004)
+		echo 'SUBDIRS-=cmake installed_cmake' >> "${S}"/tests/auto/auto.pro || die
+	fi
 
 	pushd "${QT5_BUILD_DIR}" >/dev/null || die
 


### PR DESCRIPTION
Moving [gentoo#14222](https://github.com/gentoo/gentoo/pull/14222) to the right place.