### PR TITLE
dev-qt/qtgui: More fine-grained subslot

### DIFF
--- a/dev-qt/qtgui/qtgui-5.14.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.14.9999.ebuild
@@ -7,6 +7,7 @@ QT5_MODULE="qtbase"
 inherit qt5-build
 
 DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+SLOT=5/${PV} # bug 707658
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtgui/qtgui-5.15.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.9999.ebuild
@@ -7,6 +7,7 @@ QT5_MODULE="qtbase"
 inherit qt5-build
 
 DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+SLOT=5/${PV} # bug 707658
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -7,6 +7,7 @@ QT5_MODULE="qtbase"
 inherit qt5-build
 
 DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+SLOT=5/${PV} # bug 707658
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/707658
Package-Manager: Portage-2.3.87, Repoman-2.3.20
Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>