### PR TITLE
dev-qt/qtwayland: USE X requires !dev-qt/qtgui[gles2]

### DIFF
--- a/dev-qt/qtwayland/qtwayland-5.14.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.14.9999.ebuild
@@ -21,6 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
+		~dev-qt/qtgui-${PV}[-gles2]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwayland/qtwayland-5.15.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.9999.ebuild
@@ -21,6 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
+		~dev-qt/qtgui-${PV}[-gles2]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -21,6 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
+		~dev-qt/qtgui-${PV}[-gles2]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)


### PR DESCRIPTION
So the first results are in wrt fixing the dev-qt/qtwayland[X] automagic by using the appropriate build switches: https://bugs.gentoo.org/713362

Please note that I think the dependency is suboptimal, even if necessary.

This affects users who globally enable gles2 for whatever reasons and don't use desktop profile for whatever reasons, where this is masked for Qt packages.

The best way to tackle this imo is to finally rename the gles2 flag, see also: https://archives.gentoo.org/gentoo-dev/message/ab302ac2ab641b1e82acad7d32308266

For `gles2-only` there is already usage found in net-libs/webkit-gtk and x11-libs/cairo.