### PR TITLE
dev-qt/*: Rename USE=gles2 to USE=gles2-only

### DIFF
--- a/dev-qt/qt3d/metadata.xml
+++ b/dev-qt/qt3d/metadata.xml
@@ -6,9 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gamepad">Add support for gamepad hardware via
-			<pkg>dev-qt/qtgamepad</pkg></flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
+		<flag name="gamepad">Add support for gamepad hardware via<pkg>dev-qt/qtgamepad</pkg></flag>
 		<flag name="qml">Build QML/QtQuick bindings</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qt3d/qt3d-5.14.9999.ebuild
+++ b/dev-qt/qt3d/qt3d-5.14.9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # TODO: tools
-IUSE="gamepad gles2 qml"
+IUSE="gamepad gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtconcurrent-${PV}
@@ -20,7 +20,7 @@ DEPEND="
 	~dev-qt/qtnetwork-${PV}
 	>=media-libs/assimp-4.0.0
 	gamepad? ( ~dev-qt/qtgamepad-${PV} )
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qt3d/qt3d-5.15.9999.ebuild
+++ b/dev-qt/qt3d/qt3d-5.15.9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # TODO: tools
-IUSE="gamepad gles2 qml"
+IUSE="gamepad gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtconcurrent-${PV}
@@ -20,7 +20,7 @@ DEPEND="
 	~dev-qt/qtnetwork-${PV}
 	>=media-libs/assimp-4.0.0
 	gamepad? ( ~dev-qt/qtgamepad-${PV} )
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qt3d/qt3d-5.9999.ebuild
+++ b/dev-qt/qt3d/qt3d-5.9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # TODO: tools
-IUSE="gamepad gles2 qml"
+IUSE="gamepad gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtconcurrent-${PV}
@@ -20,7 +20,7 @@ DEPEND="
 	~dev-qt/qtnetwork-${PV}
 	>=media-libs/assimp-4.0.0
 	gamepad? ( ~dev-qt/qtgamepad-${PV} )
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdatavis3d/metadata.xml
+++ b/dev-qt/qtdatavis3d/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="qml">Build QML/QtQuick bindings and imports</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.14.9999.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.14.9999.ebuild
@@ -11,12 +11,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
-IUSE="gles2 qml"
+IUSE="gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.15.9999.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.15.9999.ebuild
@@ -11,12 +11,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
-IUSE="gles2 qml"
+IUSE="gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdatavis3d/qtdatavis3d-5.9999.ebuild
+++ b/dev-qt/qtdatavis3d/qtdatavis3d-5.9999.ebuild
@@ -11,12 +11,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
-IUSE="gles2 qml"
+IUSE="gles2-only qml"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2=] )
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	qml? ( ~dev-qt/qtdeclarative-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtdeclarative/metadata.xml
+++ b/dev-qt/qtdeclarative/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="localstorage">Build the LocalStorage import for QtQuick (requires QtSql)</flag>
 		<flag name="vulkan">Enable support for Vulkan</flag>
 		<flag name="widgets">Enable QtWidgets support</flag>

--- a/dev-qt/qtdeclarative/qtdeclarative-5.14.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.14.9999.ebuild
@@ -11,17 +11,17 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="gles2 +jit localstorage vulkan +widgets"
+IUSE="gles2-only +jit localstorage vulkan +widgets"
 
 BDEPEND="${PYTHON_DEPS}"
-# qtgui[gles2=] is needed because of bug 504322
+# qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,vulkan=]
+	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )
-	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}
 	!<dev-qt/qtquickcontrols-5.7:5

--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.9999.ebuild
@@ -11,17 +11,17 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="gles2 +jit localstorage vulkan +widgets"
+IUSE="gles2-only +jit localstorage vulkan +widgets"
 
 BDEPEND="${PYTHON_DEPS}"
-# qtgui[gles2=] is needed because of bug 504322
+# qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,vulkan=]
+	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )
-	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}
 	!<dev-qt/qtquickcontrols-5.7:5

--- a/dev-qt/qtdeclarative/qtdeclarative-5.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.9999.ebuild
@@ -11,17 +11,17 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="gles2 +jit localstorage vulkan +widgets"
+IUSE="gles2-only +jit localstorage vulkan +widgets"
 
 BDEPEND="${PYTHON_DEPS}"
-# qtgui[gles2=] is needed because of bug 504322
+# qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,vulkan=]
+	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )
-	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2=] )
+	widgets? ( ~dev-qt/qtwidgets-${PV}[gles2-only=] )
 "
 RDEPEND="${DEPEND}
 	!<dev-qt/qtquickcontrols-5.7:5

--- a/dev-qt/qtgui/metadata.xml
+++ b/dev-qt/qtgui/metadata.xml
@@ -9,7 +9,6 @@
 		<flag name="egl">Enable EGL integration</flag>
 		<flag name="eglfs">Build the EGL Full Screen/Single Surface platform plugin</flag>
 		<flag name="evdev">Enable support for input devices via evdev</flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="ibus">Build the IBus input method plugin</flag>
 		<flag name="libinput">Enable support for input devices via <pkg>dev-libs/libinput</pkg></flag>
 		<flag name="tslib">Enable support for touchscreen devices via <pkg>x11-libs/tslib</pkg></flag>

--- a/dev-qt/qtgui/qtgui-5.14.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.14.9999.ebuild
@@ -15,7 +15,7 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus jpeg
+IUSE="accessibility dbus egl eglfs evdev +gif gles2-only ibus jpeg
 	+libinput +png tslib tuio +udev vnc vulkan wayland +X"
 REQUIRED_USE="
 	|| ( eglfs X )
@@ -23,7 +23,7 @@ REQUIRED_USE="
 	eglfs? ( egl )
 	ibus? ( dbus )
 	libinput? ( udev )
-	X? ( gles2? ( egl ) )
+	X? ( gles2-only? ( egl ) )
 "
 
 RDEPEND="
@@ -42,7 +42,7 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gles2? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
 		dev-libs/libinput:=
@@ -99,8 +99,8 @@ QT5_GENTOO_CONFIG=(
 	:system-freetype:FREETYPE
 	!:no-freetype:
 	!gif:no-gif:
-	gles2::OPENGL_ES
-	gles2:opengles2:OPENGL_ES_2
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
 	!:no-gui:
 	:system-harfbuzz:
 	!:no-harfbuzz:
@@ -169,7 +169,7 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)

--- a/dev-qt/qtgui/qtgui-5.15.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.9999.ebuild
@@ -15,7 +15,7 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus jpeg
+IUSE="accessibility dbus egl eglfs evdev +gif gles2-only ibus jpeg
 	+libinput +png tslib tuio +udev vnc vulkan wayland +X"
 REQUIRED_USE="
 	|| ( eglfs X )
@@ -23,7 +23,7 @@ REQUIRED_USE="
 	eglfs? ( egl )
 	ibus? ( dbus )
 	libinput? ( udev )
-	X? ( gles2? ( egl ) )
+	X? ( gles2-only? ( egl ) )
 "
 
 RDEPEND="
@@ -42,7 +42,7 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gles2? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
 		dev-libs/libinput:=
@@ -99,8 +99,8 @@ QT5_GENTOO_CONFIG=(
 	:system-freetype:FREETYPE
 	!:no-freetype:
 	!gif:no-gif:
-	gles2::OPENGL_ES
-	gles2:opengles2:OPENGL_ES_2
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
 	!:no-gui:
 	:system-harfbuzz:
 	!:no-harfbuzz:
@@ -169,7 +169,7 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -15,7 +15,7 @@ fi
 
 # TODO: linuxfb
 
-IUSE="accessibility dbus egl eglfs evdev +gif gles2 ibus jpeg
+IUSE="accessibility dbus egl eglfs evdev +gif gles2-only ibus jpeg
 	+libinput +png tslib tuio +udev vnc vulkan wayland +X"
 REQUIRED_USE="
 	|| ( eglfs X )
@@ -23,7 +23,7 @@ REQUIRED_USE="
 	eglfs? ( egl )
 	ibus? ( dbus )
 	libinput? ( udev )
-	X? ( gles2? ( egl ) )
+	X? ( gles2-only? ( egl ) )
 "
 
 RDEPEND="
@@ -42,7 +42,7 @@ RDEPEND="
 		x11-libs/libdrm
 	)
 	evdev? ( sys-libs/mtdev )
-	gles2? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2] )
 	jpeg? ( virtual/jpeg:0 )
 	libinput? (
 		dev-libs/libinput:=
@@ -99,8 +99,8 @@ QT5_GENTOO_CONFIG=(
 	:system-freetype:FREETYPE
 	!:no-freetype:
 	!gif:no-gif:
-	gles2::OPENGL_ES
-	gles2:opengles2:OPENGL_ES_2
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
 	!:no-gui:
 	:system-harfbuzz:
 	!:no-harfbuzz:
@@ -164,7 +164,7 @@ src_configure() {
 		-system-harfbuzz
 		$(qt_use jpeg libjpeg system)
 		$(qt_use libinput)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use png libpng system)
 		$(qt_use tslib)
 		$(qt_use udev libudev)

--- a/dev-qt/qtmultimedia/metadata.xml
+++ b/dev-qt/qtmultimedia/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gstreamer">Enable audio support via <pkg>media-libs/gstreamer</pkg></flag>
 		<flag name="qml">Build QML/QtQuick bindings and imports</flag>
 		<flag name="widgets">Build the QtMultimediaWidgets module</flag>

--- a/dev-qt/qtmultimedia/qtmultimedia-5.14.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.14.9999.ebuild
@@ -10,11 +10,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="alsa gles2 gstreamer openal pulseaudio qml widgets"
+IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
@@ -26,12 +26,12 @@ RDEPEND="
 	pulseaudio? ( media-sound/pulseaudio[glib] )
 	qml? (
 		~dev-qt/qtdeclarative-${PV}
-		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		gles2-only? ( ~dev-qt/qtgui-${PV}[egl] )
 		openal? ( media-libs/openal )
 	)
 	widgets? (
 		~dev-qt/qtopengl-${PV}
-		~dev-qt/qtwidgets-${PV}[gles2=]
+		~dev-qt/qtwidgets-${PV}[gles2-only=]
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-qt/qtmultimedia/qtmultimedia-5.15.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.15.9999.ebuild
@@ -10,11 +10,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="alsa gles2 gstreamer openal pulseaudio qml widgets"
+IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
@@ -26,12 +26,12 @@ RDEPEND="
 	pulseaudio? ( media-sound/pulseaudio[glib] )
 	qml? (
 		~dev-qt/qtdeclarative-${PV}
-		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		gles2-only? ( ~dev-qt/qtgui-${PV}[egl] )
 		openal? ( media-libs/openal )
 	)
 	widgets? (
 		~dev-qt/qtopengl-${PV}
-		~dev-qt/qtwidgets-${PV}[gles2=]
+		~dev-qt/qtwidgets-${PV}[gles2-only=]
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-qt/qtmultimedia/qtmultimedia-5.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.9999.ebuild
@@ -10,11 +10,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="alsa gles2 gstreamer openal pulseaudio qml widgets"
+IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtnetwork-${PV}
 	alsa? ( media-libs/alsa-lib )
 	gstreamer? (
@@ -26,12 +26,12 @@ RDEPEND="
 	pulseaudio? ( media-sound/pulseaudio[glib] )
 	qml? (
 		~dev-qt/qtdeclarative-${PV}
-		gles2? ( ~dev-qt/qtgui-${PV}[egl] )
+		gles2-only? ( ~dev-qt/qtgui-${PV}[egl] )
 		openal? ( media-libs/openal )
 	)
 	widgets? (
 		~dev-qt/qtopengl-${PV}
-		~dev-qt/qtwidgets-${PV}[gles2=]
+		~dev-qt/qtwidgets-${PV}[gles2-only=]
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-qt/qtopengl/metadata.xml
+++ b/dev-qt/qtopengl/metadata.xml
@@ -5,9 +5,6 @@
 		<email>qt@gentoo.org</email>
 		<name>Gentoo Qt Project</name>
 	</maintainer>
-	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
-	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>
 		<doc>https://doc.qt.io/</doc>

--- a/dev-qt/qtopengl/qtopengl-5.14.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.14.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="gles2"
+IUSE="gles2-only"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl
 "
 RDEPEND="${DEPEND}"
@@ -28,7 +28,7 @@ QT5_TARGET_SUBDIRS=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtopengl/qtopengl-5.15.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="gles2"
+IUSE="gles2-only"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl
 "
 RDEPEND="${DEPEND}"
@@ -28,7 +28,7 @@ QT5_TARGET_SUBDIRS=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtopengl/qtopengl-5.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="gles2"
+IUSE="gles2-only"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl
 "
 RDEPEND="${DEPEND}"
@@ -28,7 +28,7 @@ QT5_TARGET_SUBDIRS=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/metadata.xml
+++ b/dev-qt/qtprintsupport/metadata.xml
@@ -5,9 +5,6 @@
 		<email>qt@gentoo.org</email>
 		<name>Gentoo Qt Project</name>
 	</maintainer>
-	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
-	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>
 		<doc>https://doc.qt.io/</doc>

--- a/dev-qt/qtprintsupport/qtprintsupport-5.14.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.14.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -36,7 +36,7 @@ QT5_GENTOO_CONFIG=(
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.15.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.15.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -36,7 +36,7 @@ QT5_GENTOO_CONFIG=(
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
@@ -12,12 +12,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="cups gles2"
+IUSE="cups gles2-only"
 
 RDEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=]
-	~dev-qt/qtwidgets-${PV}[gles2=]
+	~dev-qt/qtgui-${PV}[gles2-only=]
+	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )
 "
 DEPEND="${RDEPEND}
@@ -36,7 +36,7 @@ QT5_GENTOO_CONFIG=(
 src_configure() {
 	local myconf=(
 		$(qt_use cups)
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwayland/qtwayland-5.14.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.14.9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
-		~dev-qt/qtgui-${PV}[-gles2]
+		~dev-qt/qtgui-${PV}[-gles2-only]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwayland/qtwayland-5.15.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
-		~dev-qt/qtgui-${PV}[-gles2]
+		~dev-qt/qtgui-${PV}[-gles2-only]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwayland/qtwayland-5.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-0.2.0
 	vulkan? ( dev-util/vulkan-headers )
 	X? (
-		~dev-qt/qtgui-${PV}[-gles2]
+		~dev-qt/qtgui-${PV}[-gles2-only]
 		x11-libs/libX11
 		x11-libs/libXcomposite
 	)

--- a/dev-qt/qtwebkit/metadata.xml
+++ b/dev-qt/qtwebkit/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="geolocation">Enable physical position determination via <pkg>dev-qt/qtpositioning</pkg></flag>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gstreamer">Enable HTML5 audio/video support via <pkg>media-libs/gstreamer</pkg> using SLOT 1.0</flag>
 		<flag name="hyphen">Enable hyphenation support via <pkg>dev-libs/hyphen</pkg></flag>
 		<flag name="multimedia">Enable HTML5 audio/video support via <pkg>dev-qt/qtmultimedia</pkg></flag>

--- a/dev-qt/qtwebkit/qtwebkit-5.212.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.212.9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://www.qt.io/"
 
 LICENSE="BSD LGPL-2+"
 SLOT="5/5.212"
-IUSE="geolocation gles2 +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
+IUSE="geolocation gles2-only +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
 
 REQUIRED_USE="
 	nsplugin? ( X )
@@ -63,8 +63,8 @@ DEPEND="
 	hyphen? ( dev-libs/hyphen )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_MIN_VER}[widgets] )
 	opengl? (
-		>=dev-qt/qtgui-${QT_MIN_VER}[gles2=]
-		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2=]
+		>=dev-qt/qtgui-${QT_MIN_VER}[gles2-only=]
+		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2-only=]
 	)
 	orientation? ( >=dev-qt/qtsensors-${QT_MIN_VER} )
 	printsupport? ( >=dev-qt/qtprintsupport-${QT_MIN_VER} )

--- a/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
+++ b/dev-qt/qtwebkit/qtwebkit-5.9999.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://www.qt.io/"
 
 LICENSE="BSD LGPL-2+"
 SLOT="5/5.9999"
-IUSE="crypt geolocation gles2 +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
+IUSE="crypt geolocation gles2-only +gstreamer +hyphen +jit multimedia nsplugin opengl orientation +printsupport qml webp X"
 
 REQUIRED_USE="
 	nsplugin? ( X )
@@ -65,8 +65,8 @@ DEPEND="
 	hyphen? ( dev-libs/hyphen )
 	multimedia? ( >=dev-qt/qtmultimedia-${QT_MIN_VER}[widgets] )
 	opengl? (
-		>=dev-qt/qtgui-${QT_MIN_VER}[gles2=]
-		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2=]
+		>=dev-qt/qtgui-${QT_MIN_VER}[gles2-only=]
+		>=dev-qt/qtopengl-${QT_MIN_VER}[gles2-only=]
 	)
 	orientation? ( >=dev-qt/qtsensors-${QT_MIN_VER} )
 	printsupport? ( >=dev-qt/qtprintsupport-${QT_MIN_VER} )

--- a/dev-qt/qtwidgets/metadata.xml
+++ b/dev-qt/qtwidgets/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Use GLES 2.0 or later instead of full OpenGL</flag>
 		<flag name="gtk">Build the GTK platform theme plugin</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qtwidgets/qtwidgets-5.14.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.14.9999.ebuild
@@ -13,11 +13,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 gtk +png +X"
+IUSE="gles2-only gtk +png +X"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,png=,X?]
+	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]
 		x11-libs/gtk+:3
@@ -45,7 +45,7 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use gtk)
 		-gui
 		$(qt_use png libpng system)

--- a/dev-qt/qtwidgets/qtwidgets-5.15.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.15.9999.ebuild
@@ -13,11 +13,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 gtk +png +X"
+IUSE="gles2-only gtk +png +X"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,png=,X?]
+	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]
 		x11-libs/gtk+:3
@@ -45,7 +45,7 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use gtk)
 		-gui
 		$(qt_use png libpng system)

--- a/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
@@ -13,11 +13,11 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 fi
 
 # keep IUSE defaults in sync with qtgui
-IUSE="gles2 gtk +png +X"
+IUSE="gles2-only gtk +png +X"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2=,png=,X?]
+	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]
 		x11-libs/gtk+:3
@@ -45,7 +45,7 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 src_configure() {
 	local myconf=(
-		-opengl $(usex gles2 es2 desktop)
+		-opengl $(usex gles2-only es2 desktop)
 		$(qt_use gtk)
 		-gui
 		$(qt_use png libpng system)


### PR DESCRIPTION
See also:
https://bugs.gentoo.org/627758
https://archives.gentoo.org/gentoo-dev/message/ab302ac2ab641b1e82acad7d32308266
https://github.com/gentoo/gentoo/pull/13742
https://github.com/gentoo/qt/pull/210