### PR TITLE
dev-qt: Add more slot operators

### DIFF
--- a/dev-qt/assistant/assistant-5.14.9999.ebuild
+++ b/dev-qt/assistant/assistant-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qthelp-${PV}
 	~dev-qt/qtnetwork-${PV}

--- a/dev-qt/assistant/assistant-5.15.0_beta3.ebuild
+++ b/dev-qt/assistant/assistant-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qthelp-${PV}
 	~dev-qt/qtnetwork-${PV}

--- a/dev-qt/assistant/assistant-5.15.9999.ebuild
+++ b/dev-qt/assistant/assistant-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qthelp-${PV}
 	~dev-qt/qtnetwork-${PV}

--- a/dev-qt/assistant/assistant-5.9999.ebuild
+++ b/dev-qt/assistant/assistant-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qthelp-${PV}
 	~dev-qt/qtnetwork-${PV}

--- a/dev-qt/designer/designer-5.14.9999.ebuild
+++ b/dev-qt/designer/designer-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="declarative webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}

--- a/dev-qt/designer/designer-5.15.0_beta3.ebuild
+++ b/dev-qt/designer/designer-5.15.0_beta3.ebuild
@@ -14,8 +14,8 @@ fi
 IUSE="declarative webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}

--- a/dev-qt/designer/designer-5.15.9999.ebuild
+++ b/dev-qt/designer/designer-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="declarative webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}

--- a/dev-qt/designer/designer-5.9999.ebuild
+++ b/dev-qt/designer/designer-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="declarative webkit"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}

--- a/dev-qt/linguist-tools/linguist-tools-5.14.9999.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtxml-${PV}
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/linguist-tools/linguist-tools-5.15.0_beta3.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtxml-${PV}
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/linguist-tools/linguist-tools-5.15.9999.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtxml-${PV}
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/linguist-tools/linguist-tools-5.9999.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtxml-${PV}
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/linguist/linguist-5.14.9999.ebuild
+++ b/dev-qt/linguist/linguist-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,8 +15,8 @@ IUSE=""
 
 DEPEND="
 	~dev-qt/designer-${PV}
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}
 	~dev-qt/qtxml-${PV}

--- a/dev-qt/linguist/linguist-5.15.0_beta3.ebuild
+++ b/dev-qt/linguist/linguist-5.15.0_beta3.ebuild
@@ -15,8 +15,8 @@ IUSE=""
 
 DEPEND="
 	~dev-qt/designer-${PV}
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}
 	~dev-qt/qtxml-${PV}

--- a/dev-qt/linguist/linguist-5.15.9999.ebuild
+++ b/dev-qt/linguist/linguist-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,8 +15,8 @@ IUSE=""
 
 DEPEND="
 	~dev-qt/designer-${PV}
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}
 	~dev-qt/qtxml-${PV}

--- a/dev-qt/linguist/linguist-5.9999.ebuild
+++ b/dev-qt/linguist/linguist-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,8 +15,8 @@ IUSE=""
 
 DEPEND="
 	~dev-qt/designer-${PV}
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtwidgets-${PV}
 	~dev-qt/qtxml-${PV}

--- a/dev-qt/pixeltool/pixeltool-5.14.9999.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtwidgets-${PV}
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/pixeltool/pixeltool-5.15.0_beta3.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.15.0_beta3.ebuild
@@ -14,8 +14,8 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtwidgets-${PV}
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/pixeltool/pixeltool-5.15.9999.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtwidgets-${PV}
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/pixeltool/pixeltool-5.9999.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	~dev-qt/qtwidgets-${PV}
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qdoc/qdoc-5.14.9999.ebuild
+++ b/dev-qt/qdoc/qdoc-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-devel/clang:=
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/qdoc/qdoc-5.15.0_beta3.ebuild
+++ b/dev-qt/qdoc/qdoc-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-devel/clang:=
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/qdoc/qdoc-5.15.9999.ebuild
+++ b/dev-qt/qdoc/qdoc-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-devel/clang:=
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/qdoc/qdoc-5.9999.ebuild
+++ b/dev-qt/qdoc/qdoc-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="qml"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-devel/clang:=
 	qml? ( ~dev-qt/qtdeclarative-${PV} )
 "

--- a/dev-qt/qtconcurrent/qtconcurrent-5.14.9999.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtconcurrent/qtconcurrent-5.15.0_beta3.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtconcurrent/qtconcurrent-5.15.9999.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtconcurrent/qtconcurrent-5.9999.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 RDEPEND="${DEPEND}"
 

--- a/dev-qt/qtcore/qtcore-5.14.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.14.9999.ebuild
@@ -2,10 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qtbase"
 inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
+SLOT=5/$(ver_cut 1-3)
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtcore/qtcore-5.15.0_beta3.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.0_beta3.ebuild
@@ -2,10 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qtbase"
 inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
+SLOT=5/$(ver_cut 1-3)
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtcore/qtcore-5.15.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.9999.ebuild
@@ -2,10 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qtbase"
 inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
+SLOT=5/$(ver_cut 1-3)
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -2,10 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qtbase"
 inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
+SLOT=5/$(ver_cut 1-3)
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"

--- a/dev-qt/qtdbus/qtdbus-5.14.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	>=sys-apps/dbus-1.4.20
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtdbus/qtdbus-5.15.0_beta3.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	>=sys-apps/dbus-1.4.20
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtdbus/qtdbus-5.15.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	>=sys-apps/dbus-1.4.20
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtdbus/qtdbus-5.9999.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	>=sys-apps/dbus-1.4.20
 "
 RDEPEND="${DEPEND}"

--- a/dev-qt/qtdiag/qtdiag-5.14.9999.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="+network +widgets"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	network? ( ~dev-qt/qtnetwork-${PV}[ssl] )
 	widgets? ( ~dev-qt/qtwidgets-${PV} )
 "

--- a/dev-qt/qtdiag/qtdiag-5.15.0_beta3.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.15.0_beta3.ebuild
@@ -14,8 +14,8 @@ fi
 IUSE="+network +widgets"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	network? ( ~dev-qt/qtnetwork-${PV}[ssl] )
 	widgets? ( ~dev-qt/qtwidgets-${PV} )
 "

--- a/dev-qt/qtdiag/qtdiag-5.15.9999.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="+network +widgets"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	network? ( ~dev-qt/qtnetwork-${PV}[ssl] )
 	widgets? ( ~dev-qt/qtwidgets-${PV} )
 "

--- a/dev-qt/qtdiag/qtdiag-5.9999.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,8 +14,8 @@ fi
 IUSE="+network +widgets"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}
+	~dev-qt/qtcore-${PV}:5=
+	~dev-qt/qtgui-${PV}:5=
 	network? ( ~dev-qt/qtnetwork-${PV}[ssl] )
 	widgets? ( ~dev-qt/qtwidgets-${PV} )
 "

--- a/dev-qt/qtgui/qtgui-5.14.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.14.9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 
 RDEPEND="
 	dev-libs/glib:2
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	dev-util/gtk-update-icon-cache
 	media-libs/fontconfig
 	>=media-libs/freetype-2.6.1:2

--- a/dev-qt/qtgui/qtgui-5.15.0_beta3.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.0_beta3.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 
 RDEPEND="
 	dev-libs/glib:2
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	dev-util/gtk-update-icon-cache
 	media-libs/fontconfig
 	>=media-libs/freetype-2.6.1:2

--- a/dev-qt/qtgui/qtgui-5.15.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 
 RDEPEND="
 	dev-libs/glib:2
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	dev-util/gtk-update-icon-cache
 	media-libs/fontconfig
 	>=media-libs/freetype-2.6.1:2

--- a/dev-qt/qtgui/qtgui-5.9999.ebuild
+++ b/dev-qt/qtgui/qtgui-5.9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 
 RDEPEND="
 	dev-libs/glib:2
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	dev-util/gtk-update-icon-cache
 	media-libs/fontconfig
 	>=media-libs/freetype-2.6.1:2

--- a/dev-qt/qthelp/qthelp-5.14.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtsql-${PV}[sqlite]

--- a/dev-qt/qthelp/qthelp-5.15.0_beta3.ebuild
+++ b/dev-qt/qthelp/qthelp-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtsql-${PV}[sqlite]

--- a/dev-qt/qthelp/qthelp-5.15.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtsql-${PV}[sqlite]

--- a/dev-qt/qthelp/qthelp-5.9999.ebuild
+++ b/dev-qt/qthelp/qthelp-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qtsql-${PV}[sqlite]

--- a/dev-qt/qtnetwork/qtnetwork-5.14.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.14.9999.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="bindist connman gssapi libproxy networkmanager sctp +ssl"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-libs/zlib:=
 	connman? ( ~dev-qt/qtdbus-${PV} )
 	gssapi? ( virtual/krb5 )

--- a/dev-qt/qtnetwork/qtnetwork-5.15.0_beta3.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="bindist connman gssapi libproxy networkmanager sctp +ssl"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-libs/zlib:=
 	connman? ( ~dev-qt/qtdbus-${PV} )
 	gssapi? ( virtual/krb5 )

--- a/dev-qt/qtnetwork/qtnetwork-5.15.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.9999.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE="bindist connman gssapi libproxy networkmanager sctp +ssl"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-libs/zlib:=
 	connman? ( ~dev-qt/qtdbus-${PV} )
 	gssapi? ( virtual/krb5 )

--- a/dev-qt/qtnetwork/qtnetwork-5.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE="bindist connman gssapi libproxy networkmanager sctp +ssl"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	sys-libs/zlib:=
 	connman? ( ~dev-qt/qtdbus-${PV} )
 	gssapi? ( virtual/krb5 )

--- a/dev-qt/qtopengl/qtopengl-5.14.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="gles2-only"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl

--- a/dev-qt/qtopengl/qtopengl-5.15.0_beta3.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.0_beta3.ebuild
@@ -15,7 +15,7 @@ fi
 IUSE="gles2-only"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl

--- a/dev-qt/qtopengl/qtopengl-5.15.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="gles2-only"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl

--- a/dev-qt/qtopengl/qtopengl-5.9999.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="gles2-only"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	virtual/opengl

--- a/dev-qt/qtprintsupport/qtprintsupport-5.14.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="cups gles2-only"
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )

--- a/dev-qt/qtprintsupport/qtprintsupport-5.15.0_beta3.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.15.0_beta3.ebuild
@@ -15,7 +15,7 @@ fi
 IUSE="cups gles2-only"
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )

--- a/dev-qt/qtprintsupport/qtprintsupport-5.15.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="cups gles2-only"
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )

--- a/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE="cups gles2-only"
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=]
 	~dev-qt/qtwidgets-${PV}[gles2-only=]
 	cups? ( >=net-print/cups-1.4 )

--- a/dev-qt/qtsql/qtsql-5.14.9999.ebuild
+++ b/dev-qt/qtsql/qtsql-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ REQUIRED_USE="
 "
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	freetds? ( dev-db/freetds )
 	mysql? ( dev-db/mysql-connector-c:= )
 	oci8? ( dev-db/oracle-instantclient:=[sdk] )

--- a/dev-qt/qtsql/qtsql-5.15.0_beta3.ebuild
+++ b/dev-qt/qtsql/qtsql-5.15.0_beta3.ebuild
@@ -19,7 +19,7 @@ REQUIRED_USE="
 "
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	freetds? ( dev-db/freetds )
 	mysql? ( dev-db/mysql-connector-c:= )
 	oci8? ( dev-db/oracle-instantclient:=[sdk] )

--- a/dev-qt/qtsql/qtsql-5.15.9999.ebuild
+++ b/dev-qt/qtsql/qtsql-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ REQUIRED_USE="
 "
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	freetds? ( dev-db/freetds )
 	mysql? ( dev-db/mysql-connector-c:= )
 	oci8? ( dev-db/oracle-instantclient:=[sdk] )

--- a/dev-qt/qtsql/qtsql-5.9999.ebuild
+++ b/dev-qt/qtsql/qtsql-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ REQUIRED_USE="
 "
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	freetds? ( dev-db/freetds )
 	mysql? ( dev-db/mysql-connector-c:= )
 	oci8? ( dev-db/oracle-instantclient:=[sdk] )

--- a/dev-qt/qttest/qttest-5.14.9999.ebuild
+++ b/dev-qt/qttest/qttest-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? (

--- a/dev-qt/qttest/qttest-5.15.0_beta3.ebuild
+++ b/dev-qt/qttest/qttest-5.15.0_beta3.ebuild
@@ -15,7 +15,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? (

--- a/dev-qt/qttest/qttest-5.15.9999.ebuild
+++ b/dev-qt/qttest/qttest-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? (

--- a/dev-qt/qttest/qttest-5.9999.ebuild
+++ b/dev-qt/qttest/qttest-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? (

--- a/dev-qt/qtwidgets/qtwidgets-5.14.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.14.9999.ebuild
@@ -16,7 +16,7 @@ fi
 IUSE="gles2-only gtk +png +X"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]

--- a/dev-qt/qtwidgets/qtwidgets-5.15.0_beta3.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.15.0_beta3.ebuild
@@ -16,7 +16,7 @@ fi
 IUSE="gles2-only gtk +png +X"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]

--- a/dev-qt/qtwidgets/qtwidgets-5.15.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.15.9999.ebuild
@@ -16,7 +16,7 @@ fi
 IUSE="gles2-only gtk +png +X"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]

--- a/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.9999.ebuild
@@ -16,7 +16,7 @@ fi
 IUSE="gles2-only gtk +png +X"
 
 DEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtgui-${PV}[gles2-only=,png=,X?]
 	gtk? (
 		~dev-qt/qtgui-${PV}[dbus]

--- a/dev-qt/qtxml/qtxml-5.14.9999.ebuild
+++ b/dev-qt/qtxml/qtxml-5.14.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? ( ~dev-qt/qtnetwork-${PV} )

--- a/dev-qt/qtxml/qtxml-5.15.0_beta3.ebuild
+++ b/dev-qt/qtxml/qtxml-5.15.0_beta3.ebuild
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? ( ~dev-qt/qtnetwork-${PV} )

--- a/dev-qt/qtxml/qtxml-5.15.9999.ebuild
+++ b/dev-qt/qtxml/qtxml-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? ( ~dev-qt/qtnetwork-${PV} )

--- a/dev-qt/qtxml/qtxml-5.9999.ebuild
+++ b/dev-qt/qtxml/qtxml-5.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ fi
 IUSE=""
 
 RDEPEND="
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 "
 DEPEND="${RDEPEND}
 	test? ( ~dev-qt/qtnetwork-${PV} )


### PR DESCRIPTION
In the past we had many issues related to inconsistent Qt packages. Quite simply it is possible for users to end up with half Qt 5.13.x, half 5.14.x installed. The addition of finer-grained subslots because of frequent private ABI changes between patch releases, and utilisation in affected reverse-dependencies had an unintended side-effect: They are being queued up earlier for emerge, way before all of dev-qt/* has been upgraded, making failed builds way more likely.

This package is intended to help the package manager figure out a better order.

The straw that broke the camel's back: https://gist.github.com/a17r/fc35a8582ab8ed7baa23c2cde85cf1cc

Emerge queue after the suggested change:
https://gist.github.com/a17r/dec177c618b0e28d03db668e574098fc