### PR TITLE
qt5-build.eclass: Drop obsolete in-source build workaround for >=5.14.2

### DIFF
--- a/dev-qt/qdoc/qdoc-5.14.9999.ebuild
+++ b/dev-qt/qdoc/qdoc-5.14.9999.ebuild
@@ -36,5 +36,6 @@ src_configure() {
 	# run in the root directory. bug 676948; same fix as bug 633776
 	mkdir -p "${QT5_BUILD_DIR}"/src/qdoc || die
 	qt5_qmake "${QT5_BUILD_DIR}"
+	cp src/qdoc/qtqdoc-config.pri "${QT5_BUILD_DIR}"/src/qdoc || die
 	qt5-build_src_configure
 }

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -104,10 +104,11 @@ EGIT_REPO_URI=(
 # @OUTPUT_VARIABLE
 # @DESCRIPTION:
 # Build directory for out-of-source builds.
-case ${QT5_BUILD_TYPE} in
-	live)    : ${QT5_BUILD_DIR:=${S}_build} ;;
-	release) : ${QT5_BUILD_DIR:=${S}} ;; # workaround for bug 497312
-esac
+if ver_test ${PV} -lt 5.14.2; then
+	: ${QT5_BUILD_DIR:=${S}} # workaround for bug 497312
+else
+	: ${QT5_BUILD_DIR:=${S}_build}
+fi
 
 IUSE="debug test"
 
@@ -658,7 +659,12 @@ qt5_base_configure() {
 
 	# a forwarding header is no longer created since 5.8, causing the system
 	# config to always be used. bug 599636
-	cp src/corelib/global/qconfig.h include/QtCore/ || die
+	# ${S}/include does not exist in live sources
+	local basedir="${S}/"
+	if ver_test ${PV} -lt 5.14.2 || [[ ${QT5_BUILD_TYPE} == live ]]; then
+		basedir=""
+	fi
+	cp src/corelib/global/qconfig.h "${basedir}"include/QtCore/ || die
 
 	popd >/dev/null || die
 


### PR DESCRIPTION
Fixed upstream in 5.11.1.

See also: https://bugreports.qt.io/browse/QTBUG-37417
Upstream commit 67aa365d41ebfe082b4efcfd725e4d5f08be678c

Bug: https://bugs.gentoo.org/497312
Bug: https://bugs.gentoo.org/676948

I think at least dev-qt/qdoc will need to be adapted as well for that change.