### PR TITLE
dev-qt/qtcore: enable renameat2 and getentropy conditionally

### DIFF
--- a/dev-qt/qtcore/metadata.xml
+++ b/dev-qt/qtcore/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
+		<flag name="old-kernel">disable new syscalls for Linux kernel >= 3.17</flag>
 		<flag name="systemd">Enable native journald logging support</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qtcore/qtcore-5.14.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.14.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 QT5_MODULE="qtbase"
-inherit qt5-build
+inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
 
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="icu systemd"
+IUSE="icu old-kernel systemd"
 
 DEPEND="
 	dev-libs/double-conversion:=
@@ -44,6 +44,16 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 PATCHES=( "${FILESDIR}/${PN}-5.14.1-cmake-macro-backward-compat.patch" ) # bug 703306
 
+pkg_pretend() {
+	if use kernel_linux; then
+		get_running_version
+		if kernel_is -lt 3 17 && ! use old-kernel; then
+			ewarn "The running kernel is older than 3.17. USE=old-kernel is needed for ${CATEGORY}/${PN}"
+			ewarn "to function on this kernel properly.  See Bug #669994."
+		fi
+	fi
+}
+
 src_prepare() {
 	# don't add -O3 to CXXFLAGS, bug 549140
 	sed -i -e '/CONFIG\s*+=/s/optimize_full//' src/corelib/corelib.pro || die
@@ -59,6 +69,8 @@ src_configure() {
 		-no-feature-statx	# bug 672856
 		$(qt_use icu)
 		$(qt_use !icu iconv)
+		$(qt_use !old-kernel feature-renameat2)  # needs Linux 3.16, bug 669994
+		$(qt_use !old-kernel feature-getentropy) # needs Linux 3.17, bug 669994
 		$(qt_use systemd journald)
 	)
 	qt5-build_src_configure

--- a/dev-qt/qtcore/qtcore-5.15.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 QT5_MODULE="qtbase"
-inherit qt5-build
+inherit linux-info qt5-build
 
 DESCRIPTION="Cross-platform application development framework"
 
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="icu systemd"
+IUSE="icu old-kernel systemd"
 
 DEPEND="
 	dev-libs/double-conversion:=
@@ -44,6 +44,16 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 
 PATCHES=( "${FILESDIR}/${PN}-5.14.1-cmake-macro-backward-compat.patch" ) # bug 703306
 
+pkg_pretend() {
+	if use kernel_linux; then
+		get_running_version
+		if kernel_is -lt 3 17 && ! use old-kernel; then
+			ewarn "The running kernel is older than 3.17. USE=old-kernel is needed for ${CATEGORY}/${PN}"
+			ewarn "to function on this kernel properly.  See Bug #669994."
+		fi
+	fi
+}
+
 src_prepare() {
 	# don't add -O3 to CXXFLAGS, bug 549140
 	sed -i -e '/CONFIG\s*+=/s/optimize_full//' src/corelib/corelib.pro || die
@@ -59,6 +69,8 @@ src_configure() {
 		-no-feature-statx	# bug 672856
 		$(qt_use icu)
 		$(qt_use !icu iconv)
+		$(qt_use !old-kernel feature-renameat2)  # needs Linux 3.16, bug 669994
+		$(qt_use !old-kernel feature-getentropy) # needs Linux 3.17, bug 669994
 		$(qt_use systemd journald)
 	)
 	qt5-build_src_configure


### PR DESCRIPTION
Add USE=old-kernel to switch off the new syscalls.

renameat2() and getentropy() are not available until linux-3.17.

Bug: https://bugs.gentoo.org/669994
Package-Manager: Portage-2.3.88, Repoman-2.3.18
Signed-off-by: Benda Xu <heroxbd@gentoo.org>