### PR TITLE
dev-qt/qtcore: In >=5.15, disable statx only with IUSE="old-kernel"

### DIFF
--- a/dev-qt/qtcore/metadata.xml
+++ b/dev-qt/qtcore/metadata.xml
@@ -6,7 +6,8 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="old-kernel">Disable syscalls not available on Linux kernels older than 3.17</flag>
+		<flag name="old-kernel" restrict="&lt;dev-qt/qtcore-5.15.0">Disable syscalls not available on Linux kernels older than 3.17</flag>
+		<flag name="old-kernel" restrict="&gt;=dev-qt/qtcore-5.15.0">Disable syscalls not available on Linux kernels older than 4.11</flag>
 		<flag name="systemd">Enable native journald logging support</flag>
 	</use>
 	<upstream>

--- a/dev-qt/qtcore/qtcore-5.15.0_beta3.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.0_beta3.ebuild
@@ -67,7 +67,7 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		-no-feature-statx	# bug 672856
+		-no-feature-statx # needs Linux 4.11, bug 672856
 		$(qt_use icu)
 		$(qt_use !icu iconv)
 		$(qt_use systemd journald)

--- a/dev-qt/qtcore/qtcore-5.15.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.9999.ebuild
@@ -49,9 +49,9 @@ PATCHES=( "${FILESDIR}/${PN}-5.14.1-cmake-macro-backward-compat.patch" ) # bug 7
 pkg_pretend() {
 	use kernel_linux || return
 	get_running_version
-	if kernel_is -lt 3 17 && ! use old-kernel; then
-		ewarn "The running kernel is older than 3.17. USE=old-kernel is needed for"
-		ewarn "dev-qt/qtcore to function on this kernel properly. See Bug #669994."
+	if kernel_is -lt 4 11 && ! use old-kernel; then
+		ewarn "The running kernel is older than 4.11. USE=old-kernel is needed for"
+		ewarn "dev-qt/qtcore to function on this kernel properly. Bugs #669994, #672856"
 	fi
 }
 
@@ -67,7 +67,6 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		-no-feature-statx	# bug 672856
 		$(qt_use icu)
 		$(qt_use !icu iconv)
 		$(qt_use systemd journald)
@@ -75,6 +74,7 @@ src_configure() {
 	use old-kernel && myconf+=(
 		-no-feature-renameat2 # needs Linux 3.16, bug 669994
 		-no-feature-getentropy # needs Linux 3.17, bug 669994
+		-no-feature-statx # needs Linux 4.11, bug 672856
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtcore/qtcore-5.9999.ebuild
+++ b/dev-qt/qtcore/qtcore-5.9999.ebuild
@@ -48,9 +48,9 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 pkg_pretend() {
 	use kernel_linux || return
 	get_running_version
-	if kernel_is -lt 3 17 && ! use old-kernel; then
-		ewarn "The running kernel is older than 3.17. USE=old-kernel is needed for"
-		ewarn "dev-qt/qtcore to function on this kernel properly. See Bug #669994."
+	if kernel_is -lt 4 11 && ! use old-kernel; then
+		ewarn "The running kernel is older than 4.11. USE=old-kernel is needed for"
+		ewarn "dev-qt/qtcore to function on this kernel properly. Bugs #669994, #672856"
 	fi
 }
 
@@ -66,7 +66,6 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		-no-feature-statx	# bug 672856
 		$(qt_use icu)
 		$(qt_use !icu iconv)
 		$(qt_use systemd journald)
@@ -74,6 +73,7 @@ src_configure() {
 	use old-kernel && myconf+=(
 		-no-feature-renameat2 # needs Linux 3.16, bug 669994
 		-no-feature-getentropy # needs Linux 3.17, bug 669994
+		-no-feature-statx # needs Linux 4.11, bug 672856
 	)
 	qt5-build_src_configure
 }


### PR DESCRIPTION
Now that we have this flag, we could use it to make >=5.15 a bit edgier.

Bug: https://bugs.gentoo.org/672856