### PR TITLE
dev-qt/qtwebengine: Fix using generated headers (fixes USE="-geolocation")

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.0_beta4.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.0_beta4.ebuild
@@ -91,7 +91,8 @@ src_prepare() {
 		-i src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py || die
 
 	# bug 620444 - ensure local headers are used
-	find "${S}" -type f -name "*.pr[fio]" | xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |' || die
+	find "${S}" -type f -name "*.pr[fio]" | \
+		xargs sed -i -e 's|INCLUDEPATH += |&$${QTWEBENGINE_ROOT}_build/include $${QTWEBENGINE_ROOT}/include |' || die
 
 	if use system-icu; then
 		# Sanity check to ensure that bundled copy of ICU is not used.

--- a/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
@@ -91,7 +91,8 @@ src_prepare() {
 		-i src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py || die
 
 	# bug 620444 - ensure local headers are used
-	find "${S}" -type f -name "*.pr[fio]" | xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |' || die
+	find "${S}" -type f -name "*.pr[fio]" | \
+		xargs sed -i -e 's|INCLUDEPATH += |&$${QTWEBENGINE_ROOT}_build/include $${QTWEBENGINE_ROOT}/include |' || die
 
 	if use system-icu; then
 		# Sanity check to ensure that bundled copy of ICU is not used.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/717122

Makes sense to me, but could not test build yet.