### PR TITLE
dev-qt/qtdeclarative: Trigger rebuild on dev-qt/qtgui subslot update

### DIFF
--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.9999.ebuild
@@ -17,7 +17,7 @@ BDEPEND="${PYTHON_DEPS}"
 # qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
 	~dev-qt/qtcore-${PV}
-	~dev-qt/qtgui-${PV}[gles2-only=,vulkan=]
+	~dev-qt/qtgui-${PV}:5=[gles2-only=,vulkan=]
 	~dev-qt/qtnetwork-${PV}
 	~dev-qt/qttest-${PV}
 	localstorage? ( ~dev-qt/qtsql-${PV} )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733674

5.14.2 and 5.15.0 in tree should receive revbumps for the same change, I guess.