### PR TITLE
dev-qt/qtbluetooth: Trigger rebuild on dev-qt/qtcore subslot update

### DIFF
--- a/dev-qt/qtbluetooth/qtbluetooth-5.15.9999.ebuild
+++ b/dev-qt/qtbluetooth/qtbluetooth-5.15.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ IUSE="qml"
 
 RDEPEND="
 	~dev-qt/qtconcurrent-${PV}
-	~dev-qt/qtcore-${PV}
+	~dev-qt/qtcore-${PV}:5=
 	~dev-qt/qtdbus-${PV}
 	>=net-wireless/bluez-5:=
 	qml? ( ~dev-qt/qtdeclarative-${PV} )


### PR DESCRIPTION
Uses private QtCore headers.

Package-Manager: Portage-3.0.1, Repoman-2.3.23
Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>