### PR TITLE
dev-qt: Drop IUSE=webkit

### DIFF
--- a/dev-qt/assistant/assistant-5.15.9999.ebuild
+++ b/dev-qt/assistant/assistant-5.15.9999.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qttools"
 inherit desktop qt5-build xdg-utils
 
@@ -11,7 +12,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~sparc ~x86"
 fi
 
-IUSE="webkit"
+IUSE=""
 
 DEPEND="
 	~dev-qt/qtcore-${PV}:5=
@@ -21,7 +22,6 @@ DEPEND="
 	~dev-qt/qtprintsupport-${PV}
 	~dev-qt/qtsql-${PV}[sqlite]
 	~dev-qt/qtwidgets-${PV}
-	webkit? ( >=dev-qt/qtwebkit-5.9.1:5 )
 "
 RDEPEND="${DEPEND}"
 
@@ -30,8 +30,8 @@ QT5_TARGET_SUBDIRS=(
 )
 
 src_prepare() {
-	qt_use_disable_mod webkit webkitwidgets \
-		src/assistant/assistant/assistant.pro
+	sed -e "s/qtHaveModule(webkitwidgets)/false/g" \
+		-i src/assistant/assistant/assistant.pro || die
 
 	qt5-build_src_prepare
 }

--- a/dev-qt/designer/designer-5.15.9999.ebuild
+++ b/dev-qt/designer/designer-5.15.9999.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 QT5_MODULE="qttools"
 inherit desktop qt5-build xdg-utils
 
@@ -11,7 +12,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
 fi
 
-IUSE="declarative webkit"
+IUSE="declarative"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}:5=
@@ -21,7 +22,6 @@ DEPEND="
 	~dev-qt/qtwidgets-${PV}
 	~dev-qt/qtxml-${PV}
 	declarative? ( ~dev-qt/qtdeclarative-${PV}[widgets] )
-	webkit? ( >=dev-qt/qtwebkit-5.9.1:5 )
 "
 RDEPEND="${DEPEND}"
 
@@ -29,8 +29,8 @@ src_prepare() {
 	qt_use_disable_mod declarative quickwidgets \
 		src/designer/src/plugins/plugins.pro
 
-	qt_use_disable_mod webkit webkitwidgets \
-		src/designer/src/plugins/plugins.pro
+	sed -e "s/qtHaveModule(webkitwidgets)/false/g" \
+		-i src/designer/src/plugins/plugins.pro || die
 
 	qt5-build_src_prepare
 }

--- a/dev-qt/designer/metadata.xml
+++ b/dev-qt/designer/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="declarative">Build the qdeclarativeview plugin</flag>
-		<flag name="webkit">Build the qwebview plugin</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>


### PR DESCRIPTION
[qtwebkit-removal](https://bugs.gentoo.org/show_bug.cgi?id=qtwebkit-removal) is progressing well and it is probably time to remove any ties from `dev-qt` category.