### PR TITLE
qt5-build.eclass cleanup

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -112,10 +112,9 @@ BDEPEND="
 if [[ ${PN} != qttest ]]; then
 	DEPEND+=" test? ( ~dev-qt/qttest-${PV} )"
 fi
-RDEPEND="
-	dev-qt/qtchooser
-"
-
+if ver_test -lt 5.15.2; then
+	RDEPEND+=" dev-qt/qtchooser"
+fi
 
 ######  Phase functions  ######
 
@@ -258,22 +257,23 @@ qt5-build_src_install() {
 			"${D}${QT5_HEADERDIR}"/QtCore/qconfig.h \
 			|| die "sed failed (qconfig.h)"
 
-		# install qtchooser configuration file
-		cat > "${T}/qt5-${CHOST}.conf" <<-_EOF_ || die
-			${QT5_BINDIR}
-			${QT5_LIBDIR}
-		_EOF_
+		if ver_test -lt 5.15.2-r2; then
+			# install qtchooser configuration file
+			cat > "${T}/qt5-${CHOST}.conf" <<-_EOF_ || die
+				${QT5_BINDIR}
+				${QT5_LIBDIR}
+			_EOF_
 
-		(
-			insinto /etc/xdg/qtchooser
-			doins "${T}/qt5-${CHOST}.conf"
-		)
+			(
+				insinto /etc/xdg/qtchooser
+				doins "${T}/qt5-${CHOST}.conf"
+			)
 
-		# convenience symlinks
-		dosym qt5-"${CHOST}".conf /etc/xdg/qtchooser/5.conf
-		dosym qt5-"${CHOST}".conf /etc/xdg/qtchooser/qt5.conf
-		# TODO bug 522646: write an eselect module to manage default.conf
-		dosym qt5.conf /etc/xdg/qtchooser/default.conf
+			# convenience symlinks
+			dosym qt5-"${CHOST}".conf /etc/xdg/qtchooser/5.conf
+			dosym qt5-"${CHOST}".conf /etc/xdg/qtchooser/qt5.conf
+			dosym qt5.conf /etc/xdg/qtchooser/default.conf
+		fi
 	fi
 
 	qt5_install_module_config


### PR DESCRIPTION
- sync with gentoo.git dropping `dev-qt/qtchooser` from default `RDEPEND` but stop short of picking https://github.com/gentoo/gentoo/commit/072da15f03fea298ef12bfec3ea8ac95f85a15d5 (not necessary imo and so qt overlay users may test w/o Qt binaries in `PATH`)
- plus move qtchooser config from eclass to qtchooser ebuild, both picked from https://github.com/gentoo/gentoo/pull/18810 