### PR TITLE
x11-libs/libfm-qt: fix mime info cache, media-gfx/lximage-qt: fix desktop database cache

### DIFF
--- a/media-gfx/lximage-qt/lximage-qt-9999.ebuild
+++ b/media-gfx/lximage-qt/lximage-qt-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake
+inherit cmake xdg-utils
 
 DESCRIPTION="LXImage Image Viewer - GPicView replacement"
 HOMEPAGE="https://lxqt.org/"
@@ -40,3 +40,11 @@ DEPEND="
 	x11-libs/libXfixes
 "
 RDEPEND="${DEPEND}"
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+}

--- a/x11-libs/libfm-qt/libfm-qt-9999.ebuild
+++ b/x11-libs/libfm-qt/libfm-qt-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake
+inherit cmake xdg-utils
 
 DESCRIPTION="Qt port of libfm, a library providing components to build desktop file managers"
 HOMEPAGE="https://lxqt.org/"
@@ -35,3 +35,11 @@ DEPEND="
 	x11-libs/libxcb:=
 "
 RDEPEND="${DEPEND}"
+
+pkg_postinst() {
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	xdg_mimeinfo_database_update
+}


### PR DESCRIPTION
x11-libs/libfm-qt: fix QA warning
Fix a QA warning regarding mime-info cache.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net

media-gfx/lximage-qt: fix QA warning
Fix a QA warning regarding desktop database cache.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
