### PR TITLE
Use KDE upstream for 5.15 live builds.

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
@@ -16,6 +16,12 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 		S="${WORKDIR}/${P}"
 		QT5_BUILD_DIR="${S}_build"
 	fi
+else
+	EGIT_BRANCH="5.15"
+	EGIT_REPO_URI=(
+		"https://code.qt.io/qt/${QT5_MODULE}.git"
+		"https://github.com/qt/${QT5_MODULE}.git"
+	)
 fi
 
 # patchset based on https://github.com/chromium-ppc64le releases

--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -67,10 +67,11 @@ QT5_MINOR_VERSION=$(ver_cut 2)
 readonly QT5_MINOR_VERSION
 
 case ${PV} in
-	5.??.9999)
-		# git stable branch
+	5.15.9999)
+		# KDE upstream for 5.15 patches
+		HOMEPAGE+=" https://invent.kde.org/qt/qt/"
 		QT5_BUILD_TYPE="live"
-		EGIT_BRANCH=${PV%.9999}
+		EGIT_BRANCH="kde/5.15"
 		;;
 	*_alpha*|*_beta*|*_rc*)
 		# development release
@@ -89,10 +90,8 @@ case ${PV} in
 esac
 readonly QT5_BUILD_TYPE
 
-EGIT_REPO_URI=(
-	"https://code.qt.io/qt/${QT5_MODULE}.git"
-	"https://github.com/qt/${QT5_MODULE}.git"
-)
+EGIT_REPO_URI=( "https://invent.kde.org/qt/qt/${QT5_MODULE}.git" )
+
 [[ ${QT5_BUILD_TYPE} == live ]] && inherit git-r3
 
 # @ECLASS-VARIABLE: QT5_BUILD_DIR


### PR DESCRIPTION
What do we think about this?

Should we wait and see for a while longer, or go ahead and make use of it?
