### PR TITLE
dev-qt/qtwebengine: Move 'net-libs/nodejs' to BDEPEND

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.9999.ebuild
@@ -84,13 +84,12 @@ RDEPEND="
 		~dev-qt/qtwidgets-${QTVER}
 	)
 "
-DEPEND="${RDEPEND}
+BDEPEND="${RDEPEND}
 	${PYTHON_DEPS}
-	>=app-arch/gzip-1.7
 	dev-util/gperf
 	dev-util/ninja
 	dev-util/re2c
-	net-libs/nodejs
+	net-libs/nodejs[inspector]
 	sys-devel/bison
 "
 


### PR DESCRIPTION
This fixes commit 2d6ef7e74ec98657341817ab7bd2663ad2679b2e, where nodejs
was added as a build-time dependency, but put into DEPEND.
See: https://devmanual.gentoo.org/general-concepts/dependencies/index.html
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Nils Freydank <holgersson@posteo.de>
