### PR TITLE
x11-misc/pcmanfm-qt: remove obsolete virtual/eject dependency

### DIFF
--- a/x11-misc/pcmanfm-qt/pcmanfm-qt-9999.ebuild
+++ b/x11-misc/pcmanfm-qt/pcmanfm-qt-9999.ebuild
@@ -33,7 +33,6 @@ DEPEND="
 	=x11-libs/libfm-qt-$(ver_cut 1-2)*
 	x11-libs/libxcb:=
 	x11-misc/xdg-utils
-	virtual/eject
 	virtual/freedesktop-icon-theme
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

virtual/eject has been removed from ::gentoo. The file /usr/bin/eject is covered by the util-linux package, which is part of the system set, AFAIK.
