### PR TITLE
dev-qt: Switch GL/EGL impl to media-libs/libglvnd

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.2.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.2.9999.ebuild
@@ -55,7 +55,6 @@ RDEPEND="
 	media-libs/libpng:0=
 	>=media-libs/libvpx-1.5:=[svc(+)]
 	media-libs/libwebp:=
-	media-libs/mesa[egl,X(+)]
 	media-libs/opus
 	sys-apps/dbus
 	sys-apps/pciutils
@@ -86,7 +85,9 @@ RDEPEND="
 		=dev-qt/qtwidgets-${QT5_PV}*
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	media-libs/libglvnd
+"
 BDEPEND="${PYTHON_DEPS}
 	dev-util/gperf
 	dev-util/ninja


### PR DESCRIPTION
This is not yet very comprehensively looked into, basically the result of `emerge -Cv libglvnd` output:

```
- /usr/lib64/libEGL.so.1
- /usr/lib64/libEGL.so.1.1.0
   .../qt5/plugins/platforms/libqwayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/platforms/libqwayland-xcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libdmabuf-server.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libdrm-egl-server.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libqt-plugin-wayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libxcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-dmabuf-server-buffer.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-drm-egl-server-buffer.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-linux-dmabuf-unstable-v1.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-wayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-wayland-eglstream-controller.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/xcbglintegrations/libqxcb-egl-integration.so (dev-qt/qtgui-5.15.2-r11)

- /usr/lib64/libGL.so.1
- /usr/lib64/libGL.so.1.7.0
   .../libQt5Gui.so.5.15.2 (dev-qt/qtgui-5.15.2-r11)
   .../libQt5MultimediaWidgets.so.5.15.2 (dev-qt/qtmultimedia-5.15.2-r1)
   .../libQt5QuickParticles.so.5.15.2 (dev-qt/qtdeclarative-5.15.2-r11)
   .../libQt5WaylandCompositor.so.5.15.2 (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/platforms/libqoffscreen.so (dev-qt/qtgui-5.15.2-r11)
   .../qt5/plugins/platforms/libqwayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/platforms/libqwayland-xcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/platforms/libqwayland-xcomposite-glx.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libdmabuf-server.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libdrm-egl-server.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libqt-plugin-wayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libxcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-client/libxcomposite-glx.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-drm-egl-server-buffer.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-linux-dmabuf-unstable-v1.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-wayland-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-egl.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-glx.so (dev-qt/qtwayland-5.15.2-r11)
   .../qt5/plugins/xcbglintegrations/libqxcb-egl-integration.so (dev-qt/qtgui-5.15.2-r11)
   .../qt5/plugins/xcbglintegrations/libqxcb-glx-integration.so (dev-qt/qtgui-5.15.2-r11)
 ```