### PR TITLE
dev-qt/qtwaylandscanner split

### DIFF
--- a/dev-qt/qtwayland/qtwayland-5.15.3.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.3.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -40,4 +40,9 @@ src_configure() {
 		$(qt_use X feature-xcomposite-glx)
 	)
 	qt5-build_src_configure
+}
+
+src_install() {
+	qt5-build_src_install
+	rm "${D}${QT5_BINDIR}"/qtwaylandscanner || die
 }

--- a/dev-qt/qtwaylandscanner/metadata.xml
+++ b/dev-qt/qtwaylandscanner/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>qt@gentoo.org</email>
+		<name>Gentoo Qt Project</name>
+	</maintainer>
+	<upstream>
+		<bugs-to>https://bugreports.qt.io/</bugs-to>
+		<doc>https://doc.qt.io/</doc>
+	</upstream>
+</pkgmetadata>

--- a/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.3.9999.ebuild
+++ b/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.3.9999.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+QT5_MODULE="qtwayland"
+inherit qt5-build
+
+DESCRIPTION="Tool that generates certain boilerplate C++ code from Wayland protocol xml spec"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+SLOT=5
+
+DEPEND="=dev-qt/qtcore-${QT5_PV}*:5="
+RDEPEND="${DEPEND}
+	!<dev-qt/qtwayland-5.15.3:5
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/qtwaylandscanner
+)


### PR DESCRIPTION
Sort of a messy split, but I did not quite know how else to do it.

Ideally we would be able to split off the compositor but that is rather tricky.