### PR TITLE
x11-misc/sddm: Change RUNTIME_DIR path to "/run/sddm"

### DIFF
--- a/x11-misc/sddm/sddm-9999.ebuild
+++ b/x11-misc/sddm/sddm-9999.ebuild
@@ -110,7 +110,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_MAN_PAGES=ON
 		-DDBUS_CONFIG_FILENAME="org.freedesktop.sddm.conf"
-		-DRUNTIME_DIR=/run
+		-DRUNTIME_DIR=/run/sddm
 		-DSYSTEMD_TMPFILES_DIR="/usr/lib/tmpfiles.d"
 		-DENABLE_PAM=$(usex pam)
 		-DNO_SYSTEMD=$(usex !systemd)


### PR DESCRIPTION
The systemd tmpfiles config provided with sddm sets the permission for RUNTIME_DIR to 0711. Setting RUNTIME_DIR to "/run" results in the wrong permission set for this directory leading to bugs similar to:

https://github.com/systemd/systemd/issues/21009