### PR TITLE
x11-misc/sddm: Outsource Gentoo defaults and resulting optional RDEPENDs to gui-apps/sddm-gentoo-config

### DIFF
--- a/gui-apps/sddm-gentoo-config/metadata.xml
+++ b/gui-apps/sddm-gentoo-config/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>lxqt@gentoo.org</email>
+		<name>LXQt</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="gentoo">gentoo/qt</remote-id>
+		<bugs-to>http://bugs.gentoo.org</bugs-to>
+	</upstream>
+</pkgmetadata>

--- a/gui-apps/sddm-gentoo-config/sddm-gentoo-config-0.ebuild
+++ b/gui-apps/sddm-gentoo-config/sddm-gentoo-config-0.ebuild
@@ -1,0 +1,35 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Gentoo defaults for SDDM (Simple Desktop Display Manager)"
+HOMEPAGE="https://github.com/sddm/sddm"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="X"
+
+RDEPEND="
+	X? ( x11-base/xorg-server )
+	!X? ( dev-libs/weston )
+"
+
+src_install() {
+	touch "${T}"/01gentoo.conf || die
+
+cat <<-EOF >> "${T}"/01gentoo.conf
+[General]
+# Which display server should be used
+DisplayServer=$(usex X "x11" "wayland")
+
+# Remove qtvirtualkeyboard as InputMethod default
+InputMethod=
+EOF
+
+	insinto /etc/sddm.conf.d/
+	doins "${T}"/01gentoo.conf
+}

--- a/profiles/categories
+++ b/profiles/categories
@@ -4,6 +4,7 @@ app-emulation
 dev-libs
 dev-qt
 dev-util
+gui-apps
 lxqt-base
 media-gfx
 x11-libs

--- a/x11-misc/sddm/sddm-9999.ebuild
+++ b/x11-misc/sddm/sddm-9999.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://dev.gentoo.org/~asturm/distfiles/${PAM_TAR}.tar.xz"
 
 LICENSE="GPL-2+ MIT CC-BY-3.0 CC-BY-SA-3.0 public-domain"
 SLOT="0"
-IUSE="+elogind +qt5 systemd test +X"
+IUSE="+elogind +qt5 systemd test"
 
 REQUIRED_USE="^^ ( elogind systemd )"
 RESTRICT="!test? ( test )"
@@ -54,7 +54,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 "
 RDEPEND="${COMMON_DEPEND}
-	X? ( x11-base/xorg-server )
+	gui-apps/sddm-gentoo-config
 	!systemd? ( gui-libs/display-manager-init )
 "
 BDEPEND="
@@ -83,14 +83,6 @@ src_unpack() {
 }
 
 src_prepare() {
-	touch 01gentoo.conf || die
-
-cat <<-EOF >> 01gentoo.conf
-[General]
-# Remove qtvirtualkeyboard as InputMethod default
-InputMethod=
-EOF
-
 	cmake_src_prepare
 
 	if ! use test; then
@@ -119,9 +111,6 @@ src_configure() {
 
 src_install() {
 	cmake_src_install
-
-	insinto /etc/sddm.conf.d/
-	doins "${S}"/01gentoo.conf
 
 	# with systemd logs are sent to journald, so no point to bother in that case
 	if ! use systemd; then


### PR DESCRIPTION
methods, category and package name up for discussion.