### PR TITLE
dev-qt/qtnetwork: Drop bearer plugins (IUSE=connman,networkmanager)

### DIFF
--- a/dev-qt/qtnetwork/metadata.xml
+++ b/dev-qt/qtnetwork/metadata.xml
@@ -6,12 +6,9 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="connman">Enable <pkg>net-misc/connman</pkg>-based bearer plugin</flag>
 		<flag name="gssapi">Enable support for GSSAPI (<pkg>virtual/krb5</pkg>)</flag>
 		<flag name="libproxy">Use <pkg>net-libs/libproxy</pkg> for automatic
 			HTTP/SOCKS proxy configuration</flag>
-		<flag name="networkmanager">Enable <pkg>net-misc/networkmanager</pkg>-based
-			bearer plugin</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtnetwork/qtnetwork-5.15.10.9999.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.10.9999.ebuild
@@ -13,22 +13,17 @@ inherit qt5-build
 
 DESCRIPTION="Network abstraction library for the Qt5 framework"
 
-IUSE="connman gssapi libproxy networkmanager sctp +ssl"
+IUSE="gssapi libproxy sctp +ssl"
 
 DEPEND="
 	=dev-qt/qtcore-${QT5_PV}*:5=
 	sys-libs/zlib:=
-	connman? ( =dev-qt/qtdbus-${QT5_PV}* )
 	gssapi? ( virtual/krb5 )
 	libproxy? ( net-libs/libproxy )
-	networkmanager? ( =dev-qt/qtdbus-${QT5_PV}* )
 	sctp? ( kernel_linux? ( net-misc/lksctp-tools ) )
 	ssl? ( >=dev-libs/openssl-1.1.1:0= )
 "
-RDEPEND="${DEPEND}
-	connman? ( net-misc/connman )
-	networkmanager? ( net-misc/networkmanager )
-"
+RDEPEND="${DEPEND}"
 
 QT5_TARGET_SUBDIRS=(
 	src/network
@@ -46,17 +41,10 @@ QT5_GENTOO_PRIVATE_CONFIG=(
 	:network
 )
 
-pkg_setup() {
-	use connman && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/connman)
-	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
-}
-
 src_configure() {
 	local myconf=(
-		$(usev connman -dbus-linked)
 		$(qt_use gssapi feature-gssapi)
 		$(qt_use libproxy)
-		$(usev networkmanager -dbus-linked)
 		$(qt_use sctp)
 		$(usev ssl -openssl-linked)
 	)


### PR DESCRIPTION
Upstream in #kde-devel:
- the bearer plugins were created in another era: for Symbian, when we weren't always connected to the Internet and the user maybe didn't want to turn on their data
- now, we're always connected, so the bearer plugins are unnecessary
- they've been removed from Qt 6 due to their design problems
- so just do the same in Qt 5: don't use them
- especially when upstream has already declared "the use of this API is a design flaw"


Can not drop src/plugins/bearer/generic (builds libqgenericbearer.so) though, as without it things like akonadi (KMail remains offline) and Plasma POTD stop working.

QTBUG: https://bugreports.qt.io/browse/QTBUG-114666