### PR TITLE
dev-qt/qtwayland: make compositor APIs off-by-default optional

### DIFF
--- a/dev-qt/qtwayland/metadata.xml
+++ b/dev-qt/qtwayland/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="vulkan">Enable support for Vulkan-based server buffer integration</flag>
+		<flag name="compositor">Enable support for the wayland compositor / server APIs</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://bugreports.qt.io/</bugs-to>

--- a/dev-qt/qtwayland/qtwayland-5.15.11.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.11.9999.ebuild
@@ -13,30 +13,33 @@ inherit qt5-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 SLOT=5/${QT5_PV} # bug 815646
-IUSE="vulkan X"
+IUSE="compositor"
 
-DEPEND="
+RDEPEND="
 	dev-libs/wayland
 	=dev-qt/qtcore-${QT5_PV}*:5=
-	=dev-qt/qtdeclarative-${QT5_PV}*:5=
-	=dev-qt/qtgui-${QT5_PV}*:5=[egl,libinput,vulkan=,X?]
+	=dev-qt/qtgui-${QT5_PV}*:5=[egl,libinput]
 	media-libs/libglvnd
-	vulkan? ( dev-util/vulkan-headers )
-	X? (
-		=dev-qt/qtgui-${QT5_PV}*[-gles2-only]
-		x11-libs/libX11
-		x11-libs/libXcomposite
+	compositor? (
+		=dev-qt/qtdeclarative-${QT5_PV}*:5=
+		=dev-qt/qtgui-${QT5_PV}*:5=[vulkan]
 	)
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	compositor? ( dev-util/vulkan-headers )
+"
 BDEPEND="dev-util/wayland-scanner"
 
 src_configure() {
 	local myqmakeargs=(
 		--
-		$(qt_use vulkan feature-wayland-vulkan-server-buffer)
-		$(qt_use X feature-xcomposite-egl)
-		$(qt_use X feature-xcomposite-glx)
+		-no-feature-xcomposite-egl
+		-no-feature-xcomposite-glx
+		$(qt_use compositor feature-wayland-server)
+		$(qt_use compositor feature-wayland-dmabuf-server-buffer)
+		$(qt_use compositor feature-wayland-drm-egl-server-buffer)
+		$(qt_use compositor feature-wayland-shm-emulation-server-buffer)
+		$(qt_use compositor feature-wayland-vulkan-server-buffer)
 	)
 	qt5-build_src_configure
 }

--- a/dev-qt/qtwayland/qtwayland-5.15.11.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.11.9999.ebuild
@@ -20,6 +20,7 @@ RDEPEND="
 	=dev-qt/qtcore-${QT5_PV}*:5=
 	=dev-qt/qtgui-${QT5_PV}*:5=[egl,libinput]
 	media-libs/libglvnd
+	x11-libs/libxkbcommon
 	compositor? (
 		=dev-qt/qtdeclarative-${QT5_PV}*:5=
 		=dev-qt/qtgui-${QT5_PV}*:5=[vulkan]


### PR DESCRIPTION
Would have preferred a clean split but wayland-server depends on wayland-client in the buildsys.

- Drop IUSE vulkan: Merge with 'compositor' instead. This absolves us from having to make a default conflicting REQUIRED_USE with compositor.
- Drop IUSE X: Unused, broken upstream since 2021 and removed in Qt6. Quoting upstream from commit d4a7faff: "These plugins were created to allow testing/debugging of QtWayland- based compositors on desktops that did not support Wayland natively."

PS: Not runtime tested yet.